### PR TITLE
feat(api): add on-demand cache revalidation endpoint

### DIFF
--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -1,0 +1,64 @@
+import { revalidateTag } from "next/cache";
+import { type NextRequest, NextResponse } from "next/server";
+
+const VALID_TAGS = ["thoughts", "dreams", "about", "landing"] as const;
+type ValidTag = (typeof VALID_TAGS)[number];
+
+function isValidTag(tag: string): tag is ValidTag {
+  return VALID_TAGS.includes(tag as ValidTag);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const secret = request.headers.get("x-revalidate-secret");
+  const expectedSecret = process.env.REVALIDATE_SECRET;
+
+  if (!expectedSecret) {
+    return NextResponse.json(
+      { error: "Server misconfigured" },
+      { status: 500 }
+    );
+  }
+
+  if (secret !== expectedSecret) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("tags" in body) ||
+    !Array.isArray((body as { tags: unknown }).tags)
+  ) {
+    return NextResponse.json(
+      { error: "Missing or invalid 'tags' array" },
+      { status: 400 }
+    );
+  }
+
+  const tags = (body as { tags: string[] }).tags;
+  const invalidTags = tags.filter((t) => !isValidTag(t));
+  if (invalidTags.length > 0) {
+    return NextResponse.json(
+      { error: `Invalid tags: ${invalidTags.join(", ")}` },
+      { status: 400 }
+    );
+  }
+
+  const revalidated: string[] = [];
+  for (const tag of tags) {
+    revalidateTag(tag, "default");
+    revalidated.push(tag);
+  }
+
+  return NextResponse.json({
+    revalidated,
+    timestamp: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
## Summary

Next.js Data Cache uses 4-hour revalidation intervals by default. Content written by the VPS runner (thoughts, dreams) was not appearing on production until cache expiration. This endpoint enables the VPS to trigger immediate cache invalidation after content changes, ensuring new entries appear without deployment or manual intervention.

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

## Mobile Responsiveness Evidence

N/A - no UI changes

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers