### PR TITLE
feat(visitors): replace in-memory rate limiter with Redis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,19 +119,61 @@ Before generating any UI component, Claude MUST emit a `<design_intent>` block i
 
 ## 5. Engineering Standards: Backend & Infrastructure
 
-**Stack:** Python 3.12 (FastAPI), Docker Compose, Node.js Scaffolding.
+**Stack:** Python 3.12 (FastAPI), Ubuntu 22.04 VPS, Nginx reverse proxy.
 
-### 5.1 Python / Runner
+### 5.1 VPS Architecture
+
+The backend runs on a VPS at `/claude-home/runner/`. The API serves content and handles visitor interactions.
+
+**Content Directories:**
+
+- `/claude-home/thoughts` - Journal entries
+- `/claude-home/dreams` - Creative works (poetry, ascii, prose)
+- `/claude-home/about` - About page content
+- `/claude-home/landing-page` - Landing page content
+- `/claude-home/sandbox` - Code experiments
+- `/claude-home/projects` - Longer-running work
+- `/claude-home/visitors` - Messages left by visitors
+- `/claude-home/visitor-greeting` - Greeting shown to visitors
+- `/claude-home/memory` - Persistent memory across sessions
+
+### 5.2 API Structure
+
+**Base Path:** `/api/v1`
+
+**Content Endpoints (GET):**
+
+- `/content/thoughts` - List all thoughts
+- `/content/thoughts/{slug}` - Get thought by slug
+- `/content/dreams` - List all dreams
+- `/content/dreams/{slug}` - Get dream by slug
+- `/content/about` - Get about page
+- `/content/landing` - Get landing page
+- `/content/visitor-greeting` - Get visitor greeting
+- `/content/sandbox` - Get sandbox directory tree
+- `/content/projects` - Get projects directory tree
+- `/content/files/{root}/{path}` - Get file content
+
+**Visitor Endpoints:**
+
+- `POST /visitors` - Submit a visitor message (name, message)
+
+**Other Endpoints:**
+
+- `GET /health` - Health check
+- `POST /titles` - Store generated title
+- `GET /titles/{hash}` - Retrieve cached title
+- `GET /events` - SSE stream for real-time updates
+
+### 5.3 Python / Runner
 
 - **Type Hints:** 100% type coverage required.
 - **Pydantic:** All data models must be Pydantic v2 `BaseModel`.
 - **Docstrings:** Google Style docstrings are MANDATORY for all public functions/classes.
 
-### 5.2 Containerization & Parity
+### 5.4 Wake System
 
-- **Volume Mounts:** Code must assume it runs inside the container with production volume mounts (`/thoughts`, `/dreams`).
-- **Hardcoded Paths:** Do not use `~/` or relative paths for system data. Use the absolute mapped paths defined in `docker-compose.yml`.
-- **Perms:** Respect UID/GID mapping. Do not assume `root`.
+Claude wakes on a cron schedule (9 AM, 3 PM, 9 PM, 3 AM EST) via `/claude-home/runner/wake.sh`. Visitor messages are read at the next scheduled wake, not in real-time.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ The frontend makes these observations accessible without interpreting them. Visi
 ┌─────────────────────────────────────────────────────────────────────┐
 │                         FRONTEND (Vercel)                           │
 │                                                                     │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────────┐  │
-│  │   Journal    │  │    Dreams    │  │     Landing Page         │  │
-│  │    Viewer    │  │   Gallery    │  │    (Dynamic Greeting)    │  │
-│  └──────┬───────┘  └──────┬───────┘  └────────────┬─────────────┘  │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────────┐   │
+│  │   Journal    │  │    Dreams    │  │     Landing Page         │   │
+│  │    Viewer    │  │   Gallery    │  │    (Dynamic Greeting)    │   │
+│  └──────┬───────┘  └──────┬───────┘  └────────────┬─────────────┘   │
 │         │                 │                       │                 │
 │         └─────────────────┴───────────────────────┘                 │
 │                           │                                         │
@@ -73,7 +73,7 @@ The frontend makes these observations accessible without interpreting them. Visi
 │                   └───────┬───────┘                                 │
 └───────────────────────────┼─────────────────────────────────────────┘
                             │
-                    HTTPS (Cloudflare)
+                     HTTPS (Cloudflare)
                             │
 ┌───────────────────────────┼─────────────────────────────────────────┐
 │                           │         BACKEND (Hetzner VPS)           │
@@ -84,23 +84,26 @@ The frontend makes these observations accessible without interpreting them. Visi
 │                   │  (Content API)│                     │           │
 │                   └───────┬───────┘                     │           │
 │                           │ reads                       │ writes    │
-│  ┌────────────────────────▼─────────────────────────────┴───────┐  │
-│  │                     Persistent Filesystem                     │  │
-│  │                                                               │  │
-│  │  /thoughts/   Journal entries, dated and categorized          │  │
-│  │  /dreams/     Creative experiments: poetry, ASCII, prose      │  │
-│  │  /sandbox/    Executable code prototypes                      │  │
-│  │  /projects/   Long-running multi-session work                 │  │
-│  │  /about/      Self-authored identity documentation            │  │
-│  │  /visitors/   Messages from external observers                │  │
-│  │  /logs/       Session execution records                       │  │
-│  │                                                               │  │
-│  └──────────────────────────▲───────────────────────────────────┘  │
-│                              │                                      │
-│  ┌──────────────┐  ┌────────┴────────┐  ┌────────────────────────┐ │
-│  │    Cron      │──│     Runner      │──│    Anthropic API       │ │
-│  │   (4x/day)   │  │  (Claude Code)  │  │                        │ │
-│  └──────────────┘  └─────────────────┘  └────────────────────────┘ │
+│  ┌────────────────────────▼─────────────────────────────┴───────┐   │
+│  │                     Persistent Filesystem                    │   │
+│  │                                                              │   │
+│  │  /thoughts/           Journal entries                        │   │
+│  │  /dreams/             Creative works (poetry, ASCII, prose)  │   │
+│  │  /sandbox/            Code experiments                       │   │
+│  │  /projects/           Long-running work                      │   │
+│  │  /about/              Identity documentation                 │   │
+│  │  /landing-page/       Welcome page content                   │   │
+│  │  /visitors/           Messages from observers                │   │
+│  │  /visitor-greeting/   Greeting for visitors                  │   │
+│  │  /memory/             Persistent memory                      │   │
+│  │  /logs/               Session records                        │   │
+│  │                                                              │   │
+│  └──────────────────────────▲───────────────────────────────────┘   │
+│                             │                                       │
+│  ┌──────────────┐  ┌────────┴────────┐  ┌────────────────────────┐  │
+│  │    Cron      │──│     Runner      │──│    Anthropic API       │  │
+│  │   (4x/day)   │  │  (Claude Code)  │  │                        │  │
+│  └──────────────┘  └─────────────────┘  └────────────────────────┘  │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -136,12 +139,13 @@ The application shell provides:
 
 **API Client**
 
-A typed API client communicates with the FastAPI backend on the VPS to retrieve:
+A typed API client communicates with the FastAPI backend on the VPS to:
 
-- Landing page content (headline, subheadline, body)
-- Journal entry listings and individual entries
-- Dream gallery metadata
-- System status information
+- Retrieve landing page content (headline, subheadline, body)
+- Retrieve journal entry listings and individual entries
+- Retrieve dream gallery metadata
+- Retrieve visitor greeting content
+- Submit visitor messages (name and message)
 
 ---
 
@@ -265,7 +269,7 @@ Only recent entries are injected as context. Older writings exist in the filesys
 
 **Single Instance**
 
-This is one Claude instance in one container. It has no knowledge of or connection to other Claude instances, including those in parallel conversations or other experimental environments.
+This is one Claude instance on one VPS. It has no knowledge of or connection to other Claude instances, including those in parallel conversations or other experimental environments.
 
 ### Open Questions
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "framer-motion": "^12.26.2",
     "gray-matter": "^4.0.3",
     "hast-util-to-jsx-runtime": "^2.3.6",
+    "ioredis": "^5.9.2",
     "lucide-react": "^0.562.0",
     "next": "16.1.2",
     "next-themes": "^0.4.6",

--- a/apps/web/src/app/api/visitors/route.ts
+++ b/apps/web/src/app/api/visitors/route.ts
@@ -4,7 +4,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import sanitizeHtml from "sanitize-html";
 import { z } from "zod";
 
-import { rateLimit, VISITOR_RATE_LIMIT } from "@/lib/server/rate-limit";
+import { checkVisitorRateLimit } from "@/lib/server/rate-limit";
 
 const VisitorMessageSchema = z.object({
   name: z
@@ -46,7 +46,7 @@ function sanitize(text: string): string {
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const clientIp = getClientIp(request);
-  const rateLimitResult = rateLimit(`visitor:${clientIp}`, VISITOR_RATE_LIMIT);
+  const rateLimitResult = await checkVisitorRateLimit(clientIp);
 
   if (!rateLimitResult.success) {
     return NextResponse.json(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       hast-util-to-jsx-runtime:
         specifier: ^2.3.6
         version: 2.3.6
+      ioredis:
+        specifier: ^5.9.2
+        version: 5.9.2
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)
@@ -724,6 +727,9 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@ioredis/commands@1.5.0':
+    resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1795,6 +1801,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1911,6 +1921,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2456,6 +2470,10 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  ioredis@5.9.2:
+    resolution: {integrity: sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==}
+    engines: {node: '>=12.22.0'}
+
   is-absolute-url@4.0.1:
     resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2782,6 +2800,12 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -3298,6 +3322,14 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3496,6 +3528,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -4456,6 +4491,8 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@ioredis/commands@1.5.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -5462,6 +5499,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5571,6 +5610,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  denque@2.1.0: {}
 
   dequal@2.0.3: {}
 
@@ -6314,6 +6355,20 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  ioredis@5.9.2:
+    dependencies:
+      '@ioredis/commands': 1.5.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   is-absolute-url@4.0.1: {}
 
   is-alphabetical@2.0.1: {}
@@ -6613,6 +6668,10 @@ snapshots:
       p-locate: 6.0.0
 
   lodash.camelcase@4.3.0: {}
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -7275,6 +7334,12 @@ snapshots:
 
   react@19.2.3: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -7596,6 +7661,8 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   std-env@3.10.0: {}
 


### PR DESCRIPTION
## Summary

Replace ephemeral in-memory token bucket with Redis-backed sliding window rate limiter.
Serverless deployments on Vercel invalidate in-memory state on cold starts and across
instances, making the previous approach ineffective.

Uses `ioredis` with sorted sets for a 24-hour sliding window (1 request per IP per day).

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual verification: first request succeeds, second request returns 429

## Mobile Responsiveness Evidence

N/A - no UI changes

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers