### PR TITLE
feat(auth): implement admin authentication with GitHub OAuth

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "ioredis": "^5.9.2",
     "lucide-react": "^0.562.0",
     "next": "16.1.2",
+    "next-auth": "5.0.0-beta.30",
     "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/apps/web/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from "@/lib/server/auth";

--- a/apps/web/src/app/panel-admin/layout.tsx
+++ b/apps/web/src/app/panel-admin/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+interface AdminLayoutProps {
+  children: ReactNode;
+}
+
+export default function AdminLayout({ children }: AdminLayoutProps) {
+  return <>{children}</>;
+}

--- a/apps/web/src/app/panel-admin/login/page.tsx
+++ b/apps/web/src/app/panel-admin/login/page.tsx
@@ -1,0 +1,76 @@
+import { redirect } from "next/navigation";
+
+import { auth, signIn } from "@/lib/server/auth";
+
+interface LoginPageProps {
+  searchParams: Promise<{ error?: string; callbackUrl?: string }>;
+}
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const session = await auth();
+  const { error } = await searchParams;
+
+  if (session?.user?.isAdmin) {
+    redirect("/panel-admin");
+  }
+
+  return (
+    <main className="flex min-h-dvh flex-col items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="space-y-2 text-center">
+          <h1 className="font-heading text-2xl font-semibold tracking-tight">
+            Admin Access
+          </h1>
+          <p className="text-sm text-[--color-text-muted]">
+            Sign in with an authorized GitHub account
+          </p>
+        </div>
+
+        {error === "AccessDenied" && (
+          <div className="rounded-md bg-red-500/10 p-3 text-center text-sm text-red-400">
+            Access denied. Your account is not authorized.
+          </div>
+        )}
+
+        {error === "Configuration" && (
+          <div className="rounded-md bg-red-500/10 p-3 text-center text-sm text-red-400">
+            Authentication configuration error.
+          </div>
+        )}
+
+        <form
+          action={async () => {
+            "use server";
+            await signIn("github", { redirectTo: "/panel-admin" });
+          }}
+        >
+          <button
+            type="submit"
+            className="flex w-full items-center justify-center gap-2 rounded-md bg-[--color-surface-elevated] px-4 py-2.5 text-sm font-medium transition-colors hover:bg-[--color-surface-elevated-hover] focus-visible:ring-2 focus-visible:ring-[--color-accent] focus-visible:outline-none"
+          >
+            <GitHubIcon />
+            Continue with GitHub
+          </button>
+        </form>
+
+        <p className="text-center text-xs text-[--color-text-muted]">
+          Only authorized administrators can access this area.
+        </p>
+      </div>
+    </main>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
+      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+}

--- a/apps/web/src/app/panel-admin/page.tsx
+++ b/apps/web/src/app/panel-admin/page.tsx
@@ -1,0 +1,68 @@
+import { signOut } from "@/lib/server/auth";
+import { verifyAdminSession } from "@/lib/server/dal/auth";
+
+export default async function AdminPanelPage() {
+  const session = await verifyAdminSession();
+
+  return (
+    <main className="flex min-h-dvh flex-col p-6">
+      <header className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="font-heading text-2xl font-semibold tracking-tight">
+            Admin Panel
+          </h1>
+          <p className="text-sm text-[--color-text-muted]">
+            Signed in as {session.user.name ?? session.user.email}
+          </p>
+        </div>
+        <form
+          action={async () => {
+            "use server";
+            await signOut({ redirectTo: "/panel-admin/login" });
+          }}
+        >
+          <button
+            type="submit"
+            className="rounded-md bg-[--color-surface-elevated] px-3 py-1.5 text-sm font-medium transition-colors hover:bg-[--color-surface-elevated-hover]"
+          >
+            Sign Out
+          </button>
+        </form>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <AdminCard
+          title="Session Info"
+          description="Current authentication state"
+        >
+          <dl className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <dt className="text-[--color-text-muted]">GitHub ID</dt>
+              <dd className="font-data">{session.user.githubId}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-[--color-text-muted]">Admin</dt>
+              <dd className="font-data text-green-400">Verified</dd>
+            </div>
+          </dl>
+        </AdminCard>
+      </div>
+    </main>
+  );
+}
+
+interface AdminCardProps {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}
+
+function AdminCard({ title, description, children }: AdminCardProps) {
+  return (
+    <div className="rounded-lg border border-[--color-border] bg-[--color-surface] p-4">
+      <h2 className="font-heading text-lg font-medium">{title}</h2>
+      <p className="mb-4 text-sm text-[--color-text-muted]">{description}</p>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/lib/server/auth/config.ts
+++ b/apps/web/src/lib/server/auth/config.ts
@@ -1,0 +1,65 @@
+import type { NextAuthConfig } from "next-auth";
+import GitHub from "next-auth/providers/github";
+
+const ADMIN_GITHUB_IDS = new Set(
+  (process.env.ADMIN_GITHUB_IDS ?? "").split(",").filter(Boolean)
+);
+
+export const authConfig: NextAuthConfig = {
+  providers: [
+    GitHub({
+      clientId: process.env.AUTH_GITHUB_ID,
+      clientSecret: process.env.AUTH_GITHUB_SECRET,
+    }),
+  ],
+  pages: {
+    signIn: "/panel-admin/login",
+    error: "/panel-admin/login",
+  },
+  callbacks: {
+    authorized({ auth, request }) {
+      const isAdminRoute = request.nextUrl.pathname.startsWith("/panel-admin");
+      const isLoginPage = request.nextUrl.pathname === "/panel-admin/login";
+
+      if (!isAdminRoute) {
+        return true;
+      }
+
+      if (isLoginPage) {
+        if (auth?.user) {
+          return Response.redirect(new URL("/panel-admin", request.nextUrl));
+        }
+        return true;
+      }
+
+      return !!auth?.user;
+    },
+    jwt({ token, account, profile }) {
+      if (account && profile) {
+        token.githubId = String(profile.id);
+      }
+      return token;
+    },
+    session({ session, token }) {
+      if (token.githubId) {
+        session.user.githubId = token.githubId as string;
+        session.user.isAdmin = ADMIN_GITHUB_IDS.has(token.githubId as string);
+      }
+      return session;
+    },
+    signIn({ profile }) {
+      if (!profile?.id) {
+        return false;
+      }
+      const githubId = String(profile.id);
+      if (!ADMIN_GITHUB_IDS.has(githubId)) {
+        return false;
+      }
+      return true;
+    },
+  },
+  session: {
+    strategy: "jwt",
+    maxAge: 60 * 60, // 1 hour
+  },
+};

--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -1,0 +1,13 @@
+import "server-only";
+import "./types";
+
+import NextAuth from "next-auth";
+
+import { authConfig } from "./config";
+
+export const {
+  handlers: { GET, POST },
+  auth,
+  signIn,
+  signOut,
+} = NextAuth(authConfig);

--- a/apps/web/src/lib/server/auth/types.ts
+++ b/apps/web/src/lib/server/auth/types.ts
@@ -1,0 +1,21 @@
+import "next-auth";
+import "next-auth/jwt";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id?: string;
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+      githubId?: string;
+      isAdmin?: boolean;
+    };
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    githubId?: string;
+  }
+}

--- a/apps/web/src/lib/server/dal/auth.ts
+++ b/apps/web/src/lib/server/dal/auth.ts
@@ -1,0 +1,52 @@
+import "server-only";
+
+import { redirect } from "next/navigation";
+import { cache } from "react";
+
+import { auth } from "@/lib/server/auth";
+
+export interface AdminSession {
+  user: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    image: string | null;
+    githubId: string;
+    isAdmin: true;
+  };
+}
+
+/**
+ * Verifies the current session belongs to an authenticated admin.
+ * Memoized per request via React cache() to prevent redundant auth calls.
+ *
+ * @returns AdminSession if valid
+ * @throws Redirects to login page if not authenticated or not admin
+ */
+export const verifyAdminSession = cache(async (): Promise<AdminSession> => {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/panel-admin/login");
+  }
+
+  if (!session.user.isAdmin) {
+    redirect("/panel-admin/login?error=AccessDenied");
+  }
+
+  return session as AdminSession;
+});
+
+/**
+ * Non-redirecting version for conditional rendering.
+ * Returns null if not authenticated or not admin.
+ */
+export const getAdminSession = cache(async (): Promise<AdminSession | null> => {
+  const session = await auth();
+
+  if (!session?.user?.isAdmin) {
+    return null;
+  }
+
+  return session as AdminSession;
+});

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,11 @@
+import NextAuth from "next-auth";
+
+import { authConfig } from "@/lib/server/auth/config";
+
+const { auth } = NextAuth(authConfig);
+
+export default auth;
+
+export const config = {
+  matcher: ["/panel-admin/:path*"],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       next:
         specifier: 16.1.2
         version: 16.1.2(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next-auth:
+        specifier: 5.0.0-beta.30
+        version: 5.0.0-beta.30(next@16.1.2(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -179,6 +182,20 @@ packages:
       zod: ^3.25.0 || ^4.0.0
     peerDependenciesMeta:
       zod:
+        optional: true
+
+  '@auth/core@0.41.0':
+    resolution: {integrity: sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^6.8.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
         optional: true
 
   '@babel/code-frame@7.28.6':
@@ -822,6 +839,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -2645,6 +2665,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3048,6 +3071,22 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-auth@5.0.0-beta.30:
+    resolution: {integrity: sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
+      nodemailer: ^7.0.7
+      react: ^18.2.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -3077,6 +3116,9 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  oauth4webapi@3.8.3:
+    resolution: {integrity: sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3209,6 +3251,14 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -3982,6 +4032,14 @@ snapshots:
     optionalDependencies:
       zod: 4.3.5
 
+  '@auth/core@0.41.0':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.1.3
+      oauth4webapi: 3.8.3
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
   '@babel/code-frame@7.28.6':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -4584,6 +4642,8 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@panva/hkdf@1.2.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -6554,6 +6614,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.1.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -7125,6 +7187,12 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-auth@5.0.0-beta.30(next@16.1.2(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@auth/core': 0.41.0
+      next: 16.1.2(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+
   next-themes@0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -7156,6 +7224,8 @@ snapshots:
       - babel-plugin-macros
 
   node-releases@2.0.27: {}
+
+  oauth4webapi@3.8.3: {}
 
   object-assign@4.1.1: {}
 
@@ -7302,6 +7372,12 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Introduces admin authentication infrastructure using next-auth v5 with GitHub OAuth. Access is restricted to an allowlist of GitHub IDs defined via environment variable, enabling secure admin panel access without a database. JWT sessions with 1-hour TTL provide stateless authentication with automatic expiry.

## Test Plan

- [ ] Unit tests pass (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Type check passes (`pnpm typecheck`)
- [ ] Build succeeds (`pnpm build`)

## Mobile Responsiveness Evidence

N/A - admin panel is not public-facing and targets desktop usage.

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers