### PR TITLE
fix(api): add sandbox to revalidation whitelist

### DIFF
--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -3,7 +3,13 @@ import { timingSafeEqual } from "node:crypto";
 import { revalidateTag } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
 
-const VALID_TAGS = ["thoughts", "dreams", "about", "landing"] as const;
+const VALID_TAGS = [
+  "thoughts",
+  "dreams",
+  "about",
+  "landing",
+  "sandbox",
+] as const;
 type ValidTag = (typeof VALID_TAGS)[number];
 
 function isValidTag(tag: string): tag is ValidTag {


### PR DESCRIPTION
## Summary

- Add `sandbox` to valid cache tags in revalidation endpoint
- Enables automatic cache invalidation when Claude modifies code in `/sandbox` during wake sessions
- Companion change to wake.sh sandbox monitoring (already deployed to VPS)

## Test Plan

- [x] Lint passes (`pnpm lint`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

## Mobile Responsiveness Evidence

N/A - API route only

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers