### PR TITLE
feat(editor): add copy-to-clipboard button to code viewer header

### DIFF
--- a/apps/web/src/components/code-viewer/CodeViewer.tsx
+++ b/apps/web/src/components/code-viewer/CodeViewer.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/server/code-highlighter";
 
 import { CodeRow } from "./CodeRow";
+import { CodeViewerHeader } from "./CodeViewerHeader";
 
 export interface CodeViewerProps {
   filePath: string;
@@ -57,12 +58,12 @@ export async function CodeViewer({
 
   return (
     <div className={`code-viewer ${className ?? ""}`}>
-      <div className="code-viewer-header">
-        <span className="code-viewer-filename">{getFilename(filePath)}</span>
-        <span className="code-viewer-meta">
-          {getLanguageFromExtension(extension)} · {lineCount} lines
-        </span>
-      </div>
+      <CodeViewerHeader
+        filename={getFilename(filePath)}
+        language={getLanguageFromExtension(extension)}
+        lineCount={lineCount}
+        content={normalizedContent}
+      />
       <div className="code-viewer-content void-scrollbar" tabIndex={0}>
         <pre className="code-viewer-pre">
           <code className="code-viewer-code">

--- a/apps/web/src/components/code-viewer/CodeViewerHeader.tsx
+++ b/apps/web/src/components/code-viewer/CodeViewerHeader.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { CopyButton } from "./CopyButton";
+
+export interface CodeViewerHeaderProps {
+  filename: string;
+  language: string;
+  lineCount: number;
+  content: string;
+}
+
+export function CodeViewerHeader({
+  filename,
+  language,
+  lineCount,
+  content,
+}: CodeViewerHeaderProps) {
+  return (
+    <div className="code-viewer-header">
+      <span className="code-viewer-filename">{filename}</span>
+      <div className="flex items-center gap-2">
+        <span className="code-viewer-meta">
+          {language} · {lineCount} lines
+        </span>
+        <CopyButton content={content} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/code-viewer/CopyButton.tsx
+++ b/apps/web/src/components/code-viewer/CopyButton.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+export interface CopyButtonProps {
+  content: string;
+}
+
+export function CopyButton({ content }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable
+    }
+  }
+
+  return (
+    <motion.button
+      type="button"
+      onClick={handleCopy}
+      aria-label={copied ? "Copied" : "Copy to clipboard"}
+      className="text-text-tertiary hover:bg-elevated hover:text-text-primary focus-visible:ring-accent-cool relative flex size-7 items-center justify-center rounded transition-colors outline-none focus-visible:ring-1"
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+      transition={{ type: "spring", stiffness: 400, damping: 17 }}
+    >
+      <AnimatePresence mode="wait" initial={false}>
+        {copied ? (
+          <motion.span
+            key="check"
+            initial={{ opacity: 0, scale: 0.5 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.5 }}
+            transition={{ duration: 0.15 }}
+            className="text-accent-success"
+          >
+            <Check className="size-4" />
+          </motion.span>
+        ) : (
+          <motion.span
+            key="copy"
+            initial={{ opacity: 0, scale: 0.5 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.5 }}
+            transition={{ duration: 0.15 }}
+          >
+            <Copy className="size-4" />
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </motion.button>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a copy button to the code viewer header, positioned to the right of the file type indicator. Enables single-click clipboard copy for sandbox and project file contents.

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

## Mobile Responsiveness Evidence

N/A - button inherits existing header responsive behavior

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers