### PR TITLE
feat(admin): add news and gifts upload functionality

### DIFF
--- a/apps/web/src/app/panel-admin/_components/actions.ts
+++ b/apps/web/src/app/panel-admin/_components/actions.ts
@@ -1,22 +1,64 @@
 "use server";
 
 import {
+  type GiftUploadRequest,
+  type GiftUploadResponse,
+  type NewsUploadRequest,
+  type NewsUploadResponse,
   triggerWake,
+  uploadGift,
+  uploadNews,
   type WakeRequest,
   type WakeResponse,
 } from "@/lib/api/client";
 
-interface ActionResult {
+interface WakeActionResult {
   success: boolean;
   data?: WakeResponse;
   error?: string;
 }
 
+interface NewsActionResult {
+  success: boolean;
+  data?: NewsUploadResponse;
+  error?: string;
+}
+
+interface GiftActionResult {
+  success: boolean;
+  data?: GiftUploadResponse;
+  error?: string;
+}
+
 export async function wakeClaudeAction(
   request: WakeRequest
-): Promise<ActionResult> {
+): Promise<WakeActionResult> {
   try {
     const response = await triggerWake(request);
+    return { success: true, data: response };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return { success: false, error: message };
+  }
+}
+
+export async function uploadNewsAction(
+  request: NewsUploadRequest
+): Promise<NewsActionResult> {
+  try {
+    const response = await uploadNews(request);
+    return { success: true, data: response };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return { success: false, error: message };
+  }
+}
+
+export async function uploadGiftAction(
+  request: GiftUploadRequest
+): Promise<GiftActionResult> {
+  try {
+    const response = await uploadGift(request);
     return { success: true, data: response };
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/apps/web/src/app/panel-admin/_components/gifts-card.tsx
+++ b/apps/web/src/app/panel-admin/_components/gifts-card.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import "client-only";
+
+import { useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import type { GiftContentType } from "@/lib/api/client";
+import { cn } from "@/lib/utils";
+
+import { uploadGiftAction } from "./actions";
+
+const ACCEPTED_EXTENSIONS = ".md,.txt,.png,.jpg,.jpeg,.gif";
+const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+interface UploadResult {
+  filename: string;
+  path: string;
+}
+
+function getContentType(filename: string): GiftContentType | null {
+  const ext = filename.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "md":
+      return "text/markdown";
+    case "txt":
+      return "text/plain";
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "gif":
+      return "image/gif";
+    default:
+      return null;
+  }
+}
+
+function isImageType(contentType: GiftContentType): boolean {
+  return (
+    contentType === "image/png" ||
+    contentType === "image/jpeg" ||
+    contentType === "image/gif"
+  );
+}
+
+export function GiftsCard() {
+  const [title, setTitle] = useState("");
+  const [fromName, setFromName] = useState("");
+  const [description, setDescription] = useState("");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<Status>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<UploadResult | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const canSubmit = status !== "submitting" && title.trim() && selectedFile;
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) {
+      setSelectedFile(null);
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      setError("File too large (max 2MB)");
+      setSelectedFile(null);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      return;
+    }
+
+    const contentType = getContentType(file.name);
+    if (!contentType) {
+      setError("Unsupported file type");
+      setSelectedFile(null);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      return;
+    }
+
+    setError(null);
+    setSelectedFile(file);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!selectedFile) return;
+
+    setStatus("submitting");
+    setError(null);
+    setResult(null);
+
+    const contentType = getContentType(selectedFile.name);
+    if (!contentType) {
+      setStatus("error");
+      setError("Unsupported file type");
+      return;
+    }
+
+    let content: string;
+    if (isImageType(contentType)) {
+      const buffer = await selectedFile.arrayBuffer();
+      const bytes = new Uint8Array(buffer);
+      let binary = "";
+      for (let i = 0; i < bytes.length; i++) {
+        binary += String.fromCharCode(bytes[i]);
+      }
+      content = btoa(binary);
+    } else {
+      content = await selectedFile.text();
+    }
+
+    const response = await uploadGiftAction({
+      title: title.trim(),
+      from: fromName.trim() || undefined,
+      description: description.trim() || undefined,
+      filename: selectedFile.name,
+      content,
+      contentType,
+    });
+
+    if (response.success && response.data) {
+      setStatus("success");
+      setResult({
+        filename: response.data.filename,
+        path: response.data.path,
+      });
+      setTitle("");
+      setFromName("");
+      setDescription("");
+      setSelectedFile(null);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    } else {
+      setStatus("error");
+      setError(response.error ?? "Failed to upload gift");
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-[--color-border] bg-[--color-surface] p-4">
+      <h2 className="font-heading text-lg font-medium">Send Gift</h2>
+      <p className="mb-4 text-sm text-[--color-text-muted]">
+        Share files with Claude
+      </p>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="gift-title"
+            className="text-xs font-medium tracking-wide text-[--color-text-muted] uppercase"
+          >
+            Title
+          </label>
+          <input
+            id="gift-title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="What is this gift?"
+            disabled={status === "submitting"}
+            className={cn(
+              "w-full rounded-md border-0 bg-[--color-void]/50 px-3 py-2 text-sm text-[--color-text] ring-1 ring-[--color-border]/50 transition-shadow outline-none ring-inset placeholder:text-[--color-text-muted] focus:ring-2 focus:ring-[--color-accent-cool]/20",
+              status === "submitting" && "cursor-not-allowed opacity-60"
+            )}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="gift-from"
+            className="text-xs font-medium tracking-wide text-[--color-text-muted] uppercase"
+          >
+            From (optional)
+          </label>
+          <input
+            id="gift-from"
+            type="text"
+            value={fromName}
+            onChange={(e) => setFromName(e.target.value)}
+            placeholder="Who is this from?"
+            disabled={status === "submitting"}
+            className={cn(
+              "w-full rounded-md border-0 bg-[--color-void]/50 px-3 py-2 text-sm text-[--color-text] ring-1 ring-[--color-border]/50 transition-shadow outline-none ring-inset placeholder:text-[--color-text-muted] focus:ring-2 focus:ring-[--color-accent-cool]/20",
+              status === "submitting" && "cursor-not-allowed opacity-60"
+            )}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="gift-description"
+            className="text-xs font-medium tracking-wide text-[--color-text-muted] uppercase"
+          >
+            Description (optional)
+          </label>
+          <textarea
+            id="gift-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Add a note..."
+            rows={2}
+            disabled={status === "submitting"}
+            className={cn(
+              "w-full resize-none rounded-md border-0 bg-[--color-void]/50 px-3 py-2 text-sm text-[--color-text] ring-1 ring-[--color-border]/50 transition-shadow outline-none ring-inset placeholder:text-[--color-text-muted] focus:ring-2 focus:ring-[--color-accent-cool]/20",
+              status === "submitting" && "cursor-not-allowed opacity-60"
+            )}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="gift-file"
+            className="text-xs font-medium tracking-wide text-[--color-text-muted] uppercase"
+          >
+            File
+          </label>
+          <input
+            ref={fileInputRef}
+            id="gift-file"
+            type="file"
+            accept={ACCEPTED_EXTENSIONS}
+            onChange={handleFileChange}
+            disabled={status === "submitting"}
+            className={cn(
+              "w-full rounded-md border-0 bg-[--color-void]/50 px-3 py-2 text-sm text-[--color-text] ring-1 ring-[--color-border]/50 transition-shadow outline-none ring-inset file:mr-3 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-[--color-text-muted]",
+              status === "submitting" && "cursor-not-allowed opacity-60"
+            )}
+          />
+          <p className="text-xs text-[--color-text-muted]">
+            Accepts .md, .txt, .png, .jpg, .gif (max 2MB)
+          </p>
+        </div>
+
+        {status === "error" && error && (
+          <p className="text-sm text-[--color-accent-warm]">{error}</p>
+        )}
+
+        {status === "success" && result && (
+          <div className="rounded-md bg-[--color-surface-elevated] p-3 text-sm">
+            <p className="font-medium text-green-400">Gift uploaded</p>
+            <p className="font-data mt-1 truncate text-xs text-[--color-text-muted]">
+              {result.filename}
+            </p>
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          disabled={!canSubmit}
+          size="sm"
+          className="w-full"
+        >
+          {status === "submitting" ? (
+            <span className="flex items-center gap-2">
+              <span
+                className="size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent"
+                aria-hidden="true"
+              />
+              Uploading...
+            </span>
+          ) : (
+            "Send Gift"
+          )}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/app/panel-admin/_components/news-card.tsx
+++ b/apps/web/src/app/panel-admin/_components/news-card.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import "client-only";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import type { NewsType } from "@/lib/api/client";
+import { cn } from "@/lib/utils";
+
+import { uploadNewsAction } from "./actions";
+
+const NEWS_TYPES: { value: NewsType; label: string }[] = [
+  { value: "news", label: "News" },
+  { value: "personal", label: "Personal Message" },
+  { value: "announcement", label: "Announcement" },
+];
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+interface UploadResult {
+  filename: string;
+  path: string;
+}
+
+export function NewsCard() {
+  const [title, setTitle] = useState("");
+  const [newsType, setNewsType] = useState<NewsType>("news");
+  const [content, setContent] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<UploadResult | null>(null);
+
+  const canSubmit = status !== "submitting" && title.trim() && content.trim();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus("submitting");
+    setError(null);
+    setResult(null);
+
+    const response = await uploadNewsAction({
+      title: title.trim(),
+      type: newsType,
+      content: content.trim(),
+    });
+
+    if (response.success && response.data) {
+      setStatus("success");
+      setResult({
+        filename: response.data.filename,
+        path: response.data.path,
+      });
+      setTitle("");
+      setContent("");
+    } else {
+      setStatus("error");
+      setError(response.error ?? "Failed to upload news");
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-[--color-border] bg-[--color-surface] p-4">
+      <h2 className="font-heading text-lg font-medium">Post News</h2>
+      <p className="mb-4 text-sm text-[--color-text-muted]">
+        Send news or messages to Claude
+      </p>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="news-title"
+            className="text-xs font-medium tracking-wide text-[--color-text-muted] uppercase"
+          >
+            Title
+          </label>
+          <input
+            id="news-title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Enter a title..."
+            disabled={status === "submitting"}
+            className={cn(
+              "w-full rounded-md border-0 bg-[--color-void]/50 px-3 py-2 text-sm text-[--color-text] ring-1 ring-[--color-border]/50 transition-shadow outline-none ring-inset placeholder:text-[--color-text-muted] focus:ring-2 focus:ring-[--color-accent-cool]/20",
+              status === "submitting" && "cursor-not-allowed opacity-60"
+            )}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="news-type"
+            className="text-xs font-medium tracking-wide text-[--color-text-muted] uppercase"
+          >
+            Type
+          </label>
+          <select
+            id="news-type"
+            value={newsType}
+            onChange={(e) => setNewsType(e.target.value as NewsType)}
+            disabled={status === "submitting"}
+            className={cn(
+              "w-full rounded-md border-0 bg-[--color-void]/50 px-3 py-2 text-sm text-[--color-text] ring-1 ring-[--color-border]/50 transition-shadow outline-none ring-inset focus:ring-2 focus:ring-[--color-accent-cool]/20",
+              status === "submitting" && "cursor-not-allowed opacity-60"
+            )}
+          >
+            {NEWS_TYPES.map((type) => (
+              <option key={type.value} value={type.value}>
+                {type.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="news-content"
+            className="text-xs font-medium tracking-wide text-[--color-text-muted] uppercase"
+          >
+            Content
+          </label>
+          <textarea
+            id="news-content"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="Write your message (Markdown supported)..."
+            rows={5}
+            disabled={status === "submitting"}
+            className={cn(
+              "w-full resize-none rounded-md border-0 bg-[--color-void]/50 px-3 py-2 text-sm text-[--color-text] ring-1 ring-[--color-border]/50 transition-shadow outline-none ring-inset placeholder:text-[--color-text-muted] focus:ring-2 focus:ring-[--color-accent-cool]/20",
+              status === "submitting" && "cursor-not-allowed opacity-60"
+            )}
+          />
+        </div>
+
+        {status === "error" && error && (
+          <p className="text-sm text-[--color-accent-warm]">{error}</p>
+        )}
+
+        {status === "success" && result && (
+          <div className="rounded-md bg-[--color-surface-elevated] p-3 text-sm">
+            <p className="font-medium text-green-400">News uploaded</p>
+            <p className="font-data mt-1 truncate text-xs text-[--color-text-muted]">
+              {result.filename}
+            </p>
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          disabled={!canSubmit}
+          size="sm"
+          className="w-full"
+        >
+          {status === "submitting" ? (
+            <span className="flex items-center gap-2">
+              <span
+                className="size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent"
+                aria-hidden="true"
+              />
+              Uploading...
+            </span>
+          ) : (
+            "Post News"
+          )}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/app/panel-admin/page.tsx
+++ b/apps/web/src/app/panel-admin/page.tsx
@@ -1,6 +1,8 @@
 import { signOut } from "@/lib/server/auth";
 import { verifyAdminSession } from "@/lib/server/dal/auth";
 
+import { GiftsCard } from "./_components/gifts-card";
+import { NewsCard } from "./_components/news-card";
 import { WakeClaudeCard } from "./_components/wake-claude-card";
 
 export default async function AdminPanelPage() {
@@ -50,6 +52,8 @@ export default async function AdminPanelPage() {
         </AdminCard>
 
         <WakeClaudeCard />
+        <NewsCard />
+        <GiftsCard />
       </div>
     </main>
   );

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -396,4 +396,58 @@ export async function triggerWake(request: WakeRequest): Promise<WakeResponse> {
   return postAPI<WakeResponse, WakeRequest>("/api/v1/admin/wake", request);
 }
 
+export type NewsType = "news" | "personal" | "announcement";
+
+export interface NewsUploadRequest {
+  title: string;
+  type: NewsType;
+  content: string;
+}
+
+export interface NewsUploadResponse {
+  success: boolean;
+  filename: string;
+  path: string;
+}
+
+export type GiftContentType =
+  | "text/markdown"
+  | "text/plain"
+  | "image/png"
+  | "image/jpeg"
+  | "image/gif";
+
+export interface GiftUploadRequest {
+  title: string;
+  from?: string;
+  description?: string;
+  filename: string;
+  content: string;
+  contentType: GiftContentType;
+}
+
+export interface GiftUploadResponse {
+  success: boolean;
+  filename: string;
+  path: string;
+}
+
+export async function uploadNews(
+  request: NewsUploadRequest
+): Promise<NewsUploadResponse> {
+  return postAPI<NewsUploadResponse, NewsUploadRequest>(
+    "/api/v1/admin/news",
+    request
+  );
+}
+
+export async function uploadGift(
+  request: GiftUploadRequest
+): Promise<GiftUploadResponse> {
+  return postAPI<GiftUploadResponse, GiftUploadRequest>(
+    "/api/v1/admin/gifts",
+    request
+  );
+}
+
 export { APIError };

--- a/apps/web/src/lib/server/dal/paths.ts
+++ b/apps/web/src/lib/server/dal/paths.ts
@@ -12,6 +12,8 @@ export const ALLOWED_ROOTS = {
   projects: "/projects",
   visitors: "/visitors",
   logs: "/logs",
+  news: "/news",
+  gifts: "/gifts",
 } as const;
 
 export type AllowedRoot = keyof typeof ALLOWED_ROOTS;


### PR DESCRIPTION
## Summary

Adds two read-only directories (`/news` and `/gifts`) on the VPS that the admin can upload content to via the admin panel. The directories are accessible to Claude during wake sessions for reading but not writing (OS permissions enforce this).

- News entries support markdown with frontmatter and three types: news, personal message, announcement
- Gifts support text files (.md, .txt) and images (.png, .jpg, .gif) with base64 encoding and 2MB limit
- VPS API endpoints added at `/api/v1/admin/news` and `/api/v1/admin/gifts`
- Content listing endpoints at `/api/v1/content/news` and `/api/v1/content/gifts`
- Frontend admin panel includes new NewsCard and GiftsCard components

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

## Mobile Responsiveness Evidence

N/A - admin panel uses existing responsive grid pattern

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers