### PR TITLE
feat(admin): add HTML file support to gifts upload

### DIFF
--- a/apps/web/src/app/panel-admin/_components/gifts-card.tsx
+++ b/apps/web/src/app/panel-admin/_components/gifts-card.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 
 import { uploadGiftAction } from "./actions";
 
-const ACCEPTED_EXTENSIONS = ".md,.txt,.png,.jpg,.jpeg,.gif";
+const ACCEPTED_EXTENSIONS = ".md,.txt,.html,.png,.jpg,.jpeg,.gif";
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 
 type Status = "idle" | "submitting" | "success" | "error";
@@ -27,6 +27,8 @@ function getContentType(filename: string): GiftContentType | null {
       return "text/markdown";
     case "txt":
       return "text/plain";
+    case "html":
+      return "text/html";
     case "png":
       return "image/png";
     case "jpg":
@@ -236,7 +238,7 @@ export function GiftsCard() {
             )}
           />
           <p className="text-xs text-[--color-text-muted]">
-            Accepts .md, .txt, .png, .jpg, .gif (max 2MB)
+            Accepts .md, .txt, .html, .png, .jpg, .gif (max 2MB)
           </p>
         </div>
 

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -413,6 +413,7 @@ export interface NewsUploadResponse {
 export type GiftContentType =
   | "text/markdown"
   | "text/plain"
+  | "text/html"
   | "image/png"
   | "image/jpeg"
   | "image/gif";


### PR DESCRIPTION
## Summary

Extends the gift upload system to accept HTML files alongside existing supported formats (markdown, plain text, images). Adds `text/html` content type to frontend type definitions, file extension validation, and UI help text. Backend enum updated on VPS.

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

## Mobile Responsiveness Evidence

N/A - no UI layout changes

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers