### PR TITLE
fix(admin): increase server action body size limit for file uploads

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -26,6 +26,11 @@ const securityHeaders = [
 const nextConfig: NextConfig = {
   reactCompiler: true,
   output: "standalone",
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "3mb",
+    },
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary

Next.js server actions default to 1MB body limit. Base64-encoded images exceed this threshold (a 2MB file becomes ~2.67MB), causing upload requests to hang indefinitely. This increases the limit to 3MB to accommodate the maximum allowed file size after encoding.

## Test Plan

- [ ] Lint passes (`pnpm lint`)
- [ ] Type check passes (`pnpm typecheck`)
- [ ] Build succeeds (`pnpm build`)
- [ ] Manual test: upload a 1MB+ image via admin panel

## Mobile Responsiveness Evidence

N/A - no UI changes

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers