### PR TITLE
fix(web): add visitors tag to revalidation endpoint

### DIFF
--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -9,6 +9,7 @@ const VALID_TAGS = [
   "about",
   "landing",
   "sandbox",
+  "visitors",
 ] as const;
 type ValidTag = (typeof VALID_TAGS)[number];
 


### PR DESCRIPTION
## Summary

The visitor greeting content uses the `visitors` cache tag in `fetchVisitorGreeting`, but this tag was missing from the `VALID_TAGS` array in the revalidation endpoint. This prevented on-demand cache invalidation for visitor content updates.

## Test Plan

- [x] Type check passes (`pnpm typecheck`)
- [x] Lint passes (pre-commit hook)
- [x] Protocol Zero passes

## Mobile Responsiveness Evidence

N/A - no UI changes