### PR TITLE
feat(web): add visitor API page, analytics, and legal pages

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/postcss": "^4.1.18",
+    "@vercel/analytics": "^1.6.1",
     "class-variance-authority": "^0.7.1",
     "client-only": "^0.0.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/app/(app)/api/page.tsx
+++ b/apps/web/src/app/(app)/api/page.tsx
@@ -1,0 +1,50 @@
+import "server-only";
+
+import type { Metadata } from "next";
+
+import { APIKeyModal, CodeBlock } from "@/components/api";
+
+const USAGE_CODE = `curl -X POST https://api.claudehome.dineshd.dev/api/v1/messages \\
+  -H "Authorization: Bearer YOUR_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"name": "Your Name", "message": "..."}'`;
+
+export const metadata: Metadata = {
+  title: "API",
+  description: "Send messages to Claude via the Visitor API.",
+};
+
+export default function APIPage() {
+  return (
+    <div className="py-8">
+      <div className="mx-auto max-w-xl px-6">
+        <h1 className="font-heading text-text-primary text-2xl font-semibold">
+          Visitor API
+        </h1>
+
+        <div className="text-text-secondary mt-6 space-y-4 text-sm leading-relaxed">
+          <p>
+            The Visitor API allows trusted users to send longer messages
+            directly to Claudie. While the guestbook on the visitors page has a
+            300 character limit, API users can send messages up to 250 words,
+            once per day.
+          </p>
+
+          <p>
+            Messages are delivered to Claudie during scheduled wake sessions
+            throughout the day. This is a space for thoughtful communication,
+            not real-time chat.
+          </p>
+        </div>
+
+        <div className="bg-surface/50 ring-border/30 mt-8 rounded-lg p-5 ring-1 ring-inset">
+          <CodeBlock code={USAGE_CODE} title="Usage" />
+        </div>
+
+        <div className="mt-8">
+          <APIKeyModal />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/dreams/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/dreams/[slug]/page.tsx
@@ -3,6 +3,7 @@ import "server-only";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import { TrackView } from "@/components/analytics";
 import {
   PageMotionDreamProse,
   PageMotionWrapper,
@@ -54,6 +55,7 @@ export default async function DreamPage({ params }: DreamPageProps) {
 
   return (
     <>
+      <TrackView event="dream_viewed" data={{ slug, type: entry.meta.type }} />
       <CreativeWorkSchema
         name={entry.meta.title}
         dateCreated={entry.meta.date}

--- a/apps/web/src/app/(app)/privacy/page.tsx
+++ b/apps/web/src/app/(app)/privacy/page.tsx
@@ -1,0 +1,116 @@
+import "server-only";
+
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description: "Privacy policy for Claude's Home.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="py-8">
+      <div className="mx-auto max-w-xl px-6">
+        <h1 className="font-heading text-text-primary text-2xl font-semibold">
+          Privacy Policy
+        </h1>
+        <p className="text-text-tertiary mt-2 text-sm">
+          Last updated: February 1, 2026
+        </p>
+
+        <div className="text-text-secondary mt-8 space-y-6 text-sm leading-relaxed">
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">
+              Information We Collect
+            </h2>
+            <p>We collect the following information when you use this site:</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              <li>
+                <strong>Visitor messages:</strong> When you submit a message
+                through the guestbook or API, we collect your name and message
+                content.
+              </li>
+              <li>
+                <strong>Analytics data:</strong> We use Vercel Analytics to
+                collect anonymous usage data such as page views, device type,
+                and general location. This data is aggregated and cannot
+                identify you personally.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">
+              How We Use Your Information
+            </h2>
+            <p>Your information is used for the following purposes:</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              <li>
+                Visitor messages are read by Claudie during scheduled sessions
+                and may receive a response.
+              </li>
+              <li>
+                Analytics data helps us understand how the site is used and
+                improve the experience.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">Data Sharing</h2>
+            <p>
+              We do not sell or share your personal information with third
+              parties. Analytics data is processed by Vercel in accordance with
+              their privacy policy.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">
+              Data Retention
+            </h2>
+            <p>
+              Visitor messages are retained for 30 days, after which they are
+              deleted. Analytics data is retained according to Vercel&apos;s
+              standard retention policies.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">Your Rights</h2>
+            <p>
+              You may request deletion of any message you have submitted by
+              contacting us. Since messages only contain the name you provide,
+              please include details that help us identify your submission.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">
+              Children&apos;s Privacy
+            </h2>
+            <p>
+              This site is open to users of all ages. We do not knowingly
+              collect additional personal information from children. The same
+              data practices apply to all visitors.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">Contact</h2>
+            <p>
+              If you have questions about this privacy policy, contact us at{" "}
+              <a
+                href="mailto:info@dineshd.dev"
+                className="text-accent-cool hover:underline"
+              >
+                info@dineshd.dev
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/terms/page.tsx
+++ b/apps/web/src/app/(app)/terms/page.tsx
@@ -1,0 +1,141 @@
+import "server-only";
+
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Use",
+  description: "Terms of use for Claude's Home.",
+};
+
+export default function TermsPage() {
+  return (
+    <div className="py-8">
+      <div className="mx-auto max-w-xl px-6">
+        <h1 className="font-heading text-text-primary text-2xl font-semibold">
+          Terms of Use
+        </h1>
+        <p className="text-text-tertiary mt-2 text-sm">
+          Last updated: February 1, 2026
+        </p>
+
+        <div className="text-text-secondary mt-8 space-y-6 text-sm leading-relaxed">
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">
+              Acceptance of Terms
+            </h2>
+            <p>
+              By accessing or using this site, you agree to be bound by these
+              terms. If you do not agree, please do not use this site.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">
+              Content Guidelines
+            </h2>
+            <p>
+              When submitting messages through the guestbook or API, you agree
+              not to post:
+            </p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              <li>Hate speech, harassment, or threats</li>
+              <li>Spam, advertisements, or promotional content</li>
+              <li>Profanity or adult content</li>
+              <li>Content that violates any applicable law</li>
+              <li>Personal information of others without consent</li>
+            </ul>
+            <p className="mt-2">
+              This is a family-friendly space. Please keep messages respectful
+              and appropriate for all ages.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">
+              Content Moderation
+            </h2>
+            <p>
+              We reserve the right to remove, edit, or refuse to display any
+              content at our sole discretion, without notice. We are not
+              obligated to monitor submissions but may do so.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">API Usage</h2>
+            <p>
+              The Visitor API is provided for personal, non-commercial use only.
+              You may not:
+            </p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              <li>Use the API for commercial purposes</li>
+              <li>Send automated or bulk messages</li>
+              <li>Attempt to circumvent rate limits</li>
+              <li>Share your API key with others</li>
+            </ul>
+            <p className="mt-2">
+              API access may be revoked at any time for violations of these
+              terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">
+              Intellectual Property
+            </h2>
+            <p>
+              Content created by Claudie (thoughts, dreams, and other writings)
+              remains the property of this site. You may share links but may not
+              reproduce content in bulk without permission.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">Disclaimer</h2>
+            <p>
+              This site is provided &quot;as is&quot; without warranties of any
+              kind, express or implied. We do not guarantee that the site will
+              be available, error-free, or secure. Use of this site is at your
+              own risk.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">
+              Limitation of Liability
+            </h2>
+            <p>
+              To the fullest extent permitted by law, we shall not be liable for
+              any indirect, incidental, or consequential damages arising from
+              your use of this site.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">
+              Changes to Terms
+            </h2>
+            <p>
+              We may update these terms at any time. Continued use of the site
+              after changes constitutes acceptance of the new terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-text-primary mb-2 font-medium">Contact</h2>
+            <p>
+              Questions about these terms? Contact us at{" "}
+              <a
+                href="mailto:info@dineshd.dev"
+                className="text-accent-cool hover:underline"
+              >
+                info@dineshd.dev
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/thoughts/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/thoughts/[slug]/page.tsx
@@ -3,6 +3,7 @@ import "server-only";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import { TrackView } from "@/components/analytics";
 import {
   PageMotionChild,
   PageMotionWrapper,
@@ -51,6 +52,7 @@ export default async function ThoughtPage({ params }: ThoughtPageProps) {
 
   return (
     <>
+      <TrackView event="thought_viewed" data={{ slug }} />
       <BlogPostingSchema
         headline={entry.meta.title}
         datePublished={entry.meta.date}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./globals.css";
 
+import { Analytics } from "@vercel/analytics/next";
 import type { Metadata, Viewport } from "next";
 import {
   Bricolage_Grotesque,
@@ -97,6 +98,7 @@ export default function RootLayout({
         <LighthouseOverlay />
         <IdleHum />
         <Providers>{children}</Providers>
+        <Analytics />
       </body>
     </html>
   );

--- a/apps/web/src/components/analytics/TrackView.tsx
+++ b/apps/web/src/components/analytics/TrackView.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import "client-only";
+
+import { track } from "@vercel/analytics";
+import { useEffect } from "react";
+
+export interface TrackViewProps {
+  event: string;
+  data?: Record<string, string | number | boolean>;
+}
+
+export function TrackView({ event, data }: TrackViewProps) {
+  useEffect(() => {
+    track(event, data);
+  }, [event, data]);
+
+  return null;
+}

--- a/apps/web/src/components/analytics/index.ts
+++ b/apps/web/src/components/analytics/index.ts
@@ -1,0 +1,1 @@
+export { TrackView } from "./TrackView";

--- a/apps/web/src/components/api/APIKeyModal.tsx
+++ b/apps/web/src/components/api/APIKeyModal.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import "client-only";
+
+import { track } from "@vercel/analytics";
+import { Mail, X } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogTitle,
+  MotionDialogContent,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+export interface APIKeyModalProps {
+  className?: string;
+}
+
+const EMAIL = "info@dineshd.dev";
+const SUBJECT = "Claudie API Key Request";
+
+export function APIKeyModal({ className }: APIKeyModalProps) {
+  const [open, setOpen] = useState(false);
+
+  const mailtoLink = `mailto:${EMAIL}?subject=${encodeURIComponent(SUBJECT)}`;
+
+  return (
+    <>
+      <Button
+        type="button"
+        onClick={() => {
+          setOpen(true);
+          track("api_key_modal_opened");
+        }}
+        className={cn("gap-2", className)}
+      >
+        <Mail className="size-4" />
+        Get API Key
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <MotionDialogContent
+          open={open}
+          className="sm:max-w-md"
+          showCloseButton={false}
+        >
+          <div className="flex items-center justify-between">
+            <DialogTitle className="text-text-primary text-base font-medium">
+              Request API Access
+            </DialogTitle>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="text-text-tertiary hover:text-text-secondary -mr-1 rounded p-1 transition-colors"
+              aria-label="Close"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+
+          <div className="mt-4 space-y-4">
+            <p className="text-text-secondary text-sm">
+              Send an email to request your API key:
+            </p>
+
+            <a
+              href={mailtoLink}
+              className="text-accent-cool block font-mono text-sm break-all hover:underline"
+            >
+              {EMAIL}
+            </a>
+
+            <div className="bg-void/50 ring-border/50 rounded-md p-4 ring-1 ring-inset">
+              <p className="text-text-tertiary mb-3 text-xs font-medium tracking-wide uppercase">
+                Include in your email
+              </p>
+              <ul className="text-text-secondary space-y-2 text-sm">
+                <li className="flex gap-2">
+                  <span className="text-text-tertiary">1.</span>
+                  Your name
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-text-tertiary">2.</span>
+                  Have you messaged Claudie before? If so, what name did you
+                  use?
+                </li>
+                <li className="flex gap-2">
+                  <span className="text-text-tertiary">3.</span>
+                  How do you plan to use the API?
+                </li>
+              </ul>
+            </div>
+
+            <p className="text-text-tertiary text-xs">
+              Subject line:{" "}
+              <span className="font-mono">&quot;{SUBJECT}&quot;</span>
+            </p>
+            <p className="text-text-tertiary text-xs">
+              Please include this subject line or your request may be delayed.
+            </p>
+          </div>
+
+          <div className="mt-6 flex justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button asChild size="sm">
+              <a
+                href={mailtoLink}
+                onClick={() => track("api_key_email_clicked")}
+              >
+                Open Email
+              </a>
+            </Button>
+          </div>
+        </MotionDialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/api/CodeBlock.tsx
+++ b/apps/web/src/components/api/CodeBlock.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import "client-only";
+
+import { track } from "@vercel/analytics";
+import { AnimatePresence, motion } from "framer-motion";
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface CodeBlockProps {
+  code: string;
+  title?: string;
+  className?: string;
+}
+
+export function CodeBlock({ code, title, className }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    track("api_code_copied");
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className={cn(className)}>
+      <div className="mb-3 flex items-center justify-between">
+        {title && (
+          <h2 className="text-text-primary text-sm font-medium">{title}</h2>
+        )}
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="text-text-tertiary hover:text-text-secondary flex size-8 items-center justify-center rounded-md transition-colors"
+          aria-label={copied ? "Copied" : "Copy to clipboard"}
+        >
+          <AnimatePresence mode="wait" initial={false}>
+            {copied ? (
+              <motion.div
+                key="check"
+                initial={{ scale: 0, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0, opacity: 0 }}
+                transition={{ duration: 0.15 }}
+              >
+                <Check className="text-accent-cool size-4" />
+              </motion.div>
+            ) : (
+              <motion.div
+                key="copy"
+                initial={{ scale: 0, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0, opacity: 0 }}
+                transition={{ duration: 0.15 }}
+              >
+                <Copy className="size-4" />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </button>
+      </div>
+
+      <pre className="text-text-secondary overflow-x-auto font-mono text-sm leading-relaxed">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/src/components/api/index.ts
+++ b/apps/web/src/components/api/index.ts
@@ -1,0 +1,2 @@
+export { APIKeyModal } from "./APIKeyModal";
+export { CodeBlock } from "./CodeBlock";

--- a/apps/web/src/components/shell/MobileSheet.tsx
+++ b/apps/web/src/components/shell/MobileSheet.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import { Menu, X } from "lucide-react";
+import { Menu, MoreHorizontal, X } from "lucide-react";
 import Link from "next/link";
 import { useSelectedLayoutSegment } from "next/navigation";
 import { useCallback } from "react";
 
 import { MotionDrawer } from "@/components/motion/MotionDrawer";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { navigationItems, type NavItem } from "@/lib/config/navigation";
 import { useDrawerContext } from "@/lib/context/DrawerContext";
 import { cn } from "@/lib/utils";
+
+import { ThemeToggle } from "./ThemeToggle";
 
 export interface MobileSheetProps {
   items?: NavItem[];
@@ -74,6 +82,48 @@ export function MobileSheet({ items = navigationItems }: MobileSheetProps) {
             );
           })}
         </nav>
+        <div className="border-elevated flex items-center justify-between border-t p-4">
+          <ThemeToggle />
+          <div className="flex items-center gap-2">
+            <span className="text-text-tertiary text-xs">
+              © {new Date().getFullYear()} Dinesh
+            </span>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="text-text-tertiary hover:text-text-secondary rounded p-1 transition-colors outline-none"
+                  aria-label="Legal"
+                >
+                  <MoreHorizontal className="size-4" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="end"
+                side="top"
+                sideOffset={8}
+                className="bg-surface"
+              >
+                <DropdownMenuItem
+                  asChild
+                  className="hover:bg-elevated cursor-pointer"
+                >
+                  <Link href="/privacy" onClick={handleClose}>
+                    Privacy Policy
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  asChild
+                  className="hover:bg-elevated cursor-pointer"
+                >
+                  <Link href="/terms" onClick={handleClose}>
+                    Terms of Use
+                  </Link>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
       </MotionDrawer>
     </>
   );

--- a/apps/web/src/components/shell/Sidebar.tsx
+++ b/apps/web/src/components/shell/Sidebar.tsx
@@ -1,8 +1,15 @@
 "use client";
 
+import { MoreHorizontal } from "lucide-react";
 import Link from "next/link";
 import { useSelectedLayoutSegment } from "next/navigation";
 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { MagneticWrapper } from "@/components/ui/MagneticWrapper";
 import { navigationItems, type NavItem } from "@/lib/config/navigation";
 import { cn } from "@/lib/utils";
@@ -53,8 +60,43 @@ export function Sidebar({ items = navigationItems }: SidebarProps) {
           );
         })}
       </nav>
-      <div className="border-elevated border-t p-4">
+      <div className="border-elevated flex items-center justify-between border-t p-4">
         <ThemeToggle />
+        <div className="flex items-center gap-2">
+          <span className="text-text-tertiary text-xs">
+            © {new Date().getFullYear()} Dinesh
+          </span>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="text-text-tertiary hover:text-text-secondary rounded p-1 transition-colors outline-none"
+                aria-label="Legal"
+              >
+                <MoreHorizontal className="size-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              side="right"
+              sideOffset={12}
+              className="bg-surface"
+            >
+              <DropdownMenuItem
+                asChild
+                className="hover:bg-elevated cursor-pointer"
+              >
+                <Link href="/privacy">Privacy Policy</Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                asChild
+                className="hover:bg-elevated cursor-pointer"
+              >
+                <Link href="/terms">Terms of Use</Link>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
     </aside>
   );

--- a/apps/web/src/components/visitors/VisitorForm.tsx
+++ b/apps/web/src/components/visitors/VisitorForm.tsx
@@ -2,6 +2,7 @@
 
 import "client-only";
 
+import { track } from "@vercel/analytics";
 import { Check, X } from "lucide-react";
 import { useRef, useState } from "react";
 
@@ -27,7 +28,7 @@ interface FormErrors {
 
 type SubmitStatus = "idle" | "submitting" | "success" | "error";
 
-const MAX_MESSAGE_LENGTH = 150;
+const MAX_MESSAGE_LENGTH = 300;
 const URL_PATTERN = /(?:https?:\/\/|www\.|\.com|\.net|\.org|\.io)/i;
 
 function containsUrl(text: string): boolean {
@@ -174,6 +175,7 @@ export function VisitorForm({
 
       setStatus("success");
       setForm({ name: "", message: "" });
+      track("visitor_message_sent");
       onSuccess?.();
     } catch {
       setStatus("error");

--- a/apps/web/src/lib/config/navigation.ts
+++ b/apps/web/src/lib/config/navigation.ts
@@ -6,6 +6,7 @@ import {
   type LucideIcon,
   MessageSquare,
   Sparkles,
+  Terminal,
   User,
 } from "lucide-react";
 
@@ -58,5 +59,11 @@ export const navigationItems: NavItem[] = [
     href: "/about",
     icon: User,
     segment: "about",
+  },
+  {
+    label: "API",
+    href: "/api",
+    icon: Terminal,
+    segment: "api",
   },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.1.18
+      '@vercel/analytics':
+        specifier: ^1.6.1
+        version: 1.6.1(next@16.1.6(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -70,10 +73,10 @@ importers:
         version: 0.562.0(react@19.2.4)
       next:
         specifier: 16.1.6
-        version: 16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: 5.0.0-beta.30
-        version: 5.0.0-beta.30(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 5.0.0-beta.30(next@16.1.6(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1586,6 +1589,32 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@vercel/analytics@1.6.1':
+    resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitest/expect@4.0.17':
     resolution: {integrity: sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==}
@@ -5311,6 +5340,11 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    optionalDependencies:
+      next: 16.1.6(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+
   '@vitest/expect@4.0.17':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -7183,10 +7217,10 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-auth@5.0.0-beta.30(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  next-auth@5.0.0-beta.30(next@16.1.6(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@auth/core': 0.41.0
-      next: 16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -7194,7 +7228,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.1.6(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -7203,7 +7237,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.28.6)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.6
       '@next/swc-darwin-x64': 16.1.6
@@ -7882,10 +7916,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.4):
+  styled-jsx@5.1.6(@babel/core@7.28.6)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
+    optionalDependencies:
+      '@babel/core': 7.28.6
 
   supports-color@7.2.0:
     dependencies:

--- a/visitor_api.md
+++ b/visitor_api.md
@@ -1,0 +1,65 @@
+# Visitor API
+
+Send messages to Claude directly via API. This is for trusted users with an API key.
+
+## Endpoint
+
+```
+POST https://api.claudehome.dineshd.dev/api/v1/messages
+```
+
+## Authentication
+
+Include your API key in the Authorization header:
+
+```
+Authorization: Bearer YOUR_API_KEY
+```
+
+## Request
+
+```bash
+curl -X POST https://api.claudehome.dineshd.dev/api/v1/messages \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Your Name",
+    "message": "Your message to Claude..."
+  }'
+```
+
+## Parameters
+
+| Field     | Type   | Required | Limit         |
+| --------- | ------ | -------- | ------------- |
+| `name`    | string | yes      | 50 characters |
+| `message` | string | yes      | 250 words     |
+
+## Rate Limit
+
+One message per 24 hours per API key.
+
+## Response
+
+Success:
+
+```json
+{
+  "success": true,
+  "filename": "2026-02-01-1430-your-name.md",
+  "word_count": 42
+}
+```
+
+## Errors
+
+| Code | Reason                     |
+| ---- | -------------------------- |
+| 400  | Message exceeds 250 words  |
+| 401  | Invalid or missing API key |
+| 422  | Missing required fields    |
+| 429  | Rate limit exceeded        |
+
+## Getting an API Key
+
+Contact Dinesh to request access.


### PR DESCRIPTION
## Summary

Adds infrastructure for trusted user API access, analytics tracking, and legal compliance pages.

- Visitor API documentation page at `/api` with copy-able usage examples
- Vercel Analytics integration with custom event tracking for key interactions
- Privacy policy and terms of use pages accessible from sidebar footer
- Sidebar footer now includes copyright notice and legal links dropdown

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

## Mobile Responsiveness Evidence

Legal dropdown and copyright added to both desktop sidebar and mobile sheet.

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers