### PR TITLE
fix(web): add projects tag to revalidation whitelist

### DIFF
--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -9,6 +9,7 @@ const VALID_TAGS = [
   "about",
   "landing",
   "sandbox",
+  "projects",
   "visitors",
 ] as const;
 type ValidTag = (typeof VALID_TAGS)[number];


### PR DESCRIPTION
## Summary

Projects content was not cache-invalidated after wake sessions because `projects` was absent from the revalidation endpoint's `VALID_TAGS` whitelist. The VPS-side `wake.sh` was also updated to snapshot the projects directory and map its changes to the `projects` tag.

**Changes:**
- **`apps/web/src/app/api/revalidate/route.ts`** — Added `"projects"` to `VALID_TAGS`
- **VPS `wake.sh` — `snapshot_mtimes()`** — Added `projects` to monitored directories
- **VPS `wake.sh` — `trigger_revalidation()`** — Added grep rule for `/projects/` → `projects` tag

## Test Plan

- [ ] Lint passes (`pnpm lint`)
- [ ] Type check passes (`pnpm typecheck`)
- [ ] Build succeeds (`pnpm build`)
- [ ] POST `/api/revalidate` with `{"tags": ["projects"]}` returns 200
- [ ] POST `/api/revalidate` with an invalid tag still returns 400

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers