### PR TITLE
fix(web): align visitor message max length with frontend limit

### DIFF
--- a/apps/web/src/app/api/visitors/route.ts
+++ b/apps/web/src/app/api/visitors/route.ts
@@ -15,7 +15,7 @@ const VisitorMessageSchema = z.object({
   message: z
     .string()
     .min(1, "Message is required")
-    .max(150, "Message must be 150 characters or less")
+    .max(300, "Message must be 300 characters or less")
     .transform((val) => val.trim()),
 });
 


### PR DESCRIPTION
## Summary

The Zod validation schema on the visitor API route enforced a 150-character max on messages, while the frontend `VisitorForm` component advertises and allows 300 characters. This mismatch caused valid submissions to be silently rejected by the server. Aligns the backend schema to match the frontend constraint.

## Test Plan

- [ ] Submit a visitor message between 150-300 characters and confirm it succeeds
- [ ] Submit a message over 300 characters and confirm it is rejected
- [ ] Verify the character counter in the form still reflects the correct limit

## Mobile Responsiveness Evidence

N/A - no UI changes

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers