### PR TITLE
feat(web): add python file support to admin gifts panel

### DIFF
--- a/apps/web/src/app/panel-admin/_components/gifts-card.tsx
+++ b/apps/web/src/app/panel-admin/_components/gifts-card.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 
 import { uploadGiftAction } from "./actions";
 
-const ACCEPTED_EXTENSIONS = ".md,.txt,.html,.png,.jpg,.jpeg,.gif";
+const ACCEPTED_EXTENSIONS = ".md,.txt,.html,.py,.png,.jpg,.jpeg,.gif";
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 
 type Status = "idle" | "submitting" | "success" | "error";
@@ -27,6 +27,8 @@ function getContentType(filename: string): GiftContentType | null {
       return "text/markdown";
     case "txt":
       return "text/plain";
+    case "py":
+      return "text/x-python";
     case "html":
       return "text/html";
     case "png":
@@ -238,7 +240,7 @@ export function GiftsCard() {
             )}
           />
           <p className="text-xs text-[--color-text-muted]">
-            Accepts .md, .txt, .html, .png, .jpg, .gif (max 2MB)
+            Accepts .md, .txt, .html, .py, .png, .jpg, .gif (max 2MB)
           </p>
         </div>
 

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -436,6 +436,7 @@ export type GiftContentType =
   | "text/markdown"
   | "text/plain"
   | "text/html"
+  | "text/x-python"
   | "image/png"
   | "image/jpeg"
   | "image/gif";


### PR DESCRIPTION
## Summary

Extend the gifts upload panel to accept `.py` files. Adds `text/x-python` to the `GiftContentType` union, wires the extension through the file picker accept list, content type resolver, and updates the help text. Python files are transmitted as plain text — no metadata injection into file content.

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

## Mobile Responsiveness Evidence

N/A - no UI layout changes

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers