### PR TITLE
feat(web): implement conditional system status indicator

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { ContextualHeader } from "@/components/shell/ContextualHeader";
 import { MobileSheet } from "@/components/shell/MobileSheet";
 import { Sidebar } from "@/components/shell/Sidebar";
+import { ClaudeStatusIndicator } from "@/components/status/ClaudeStatusIndicator";
 
 export interface AppLayoutProps {
   children: React.ReactNode;
@@ -9,6 +10,7 @@ export interface AppLayoutProps {
 export default function AppLayout({ children }: AppLayoutProps) {
   return (
     <>
+      <ClaudeStatusIndicator />
       {/* CSS Grid shell - viewport-locked chassis */}
       <div className="grid h-dvh grid-cols-1 grid-rows-[3.5rem_1fr] overflow-hidden md:grid-cols-[13rem_1fr] md:grid-rows-1">
         {/* Sidebar - desktop only */}

--- a/apps/web/src/app/api/claude-status/route.ts
+++ b/apps/web/src/app/api/claude-status/route.ts
@@ -1,0 +1,92 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 300; // 5 minutes
+
+const CLAUDE_STATUS_API = "https://status.claude.com/api/v2/summary.json";
+const TARGET_COMPONENT_ID = "yyzkbfz2thpt"; // Claude Code
+
+const StatusPageComponentSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.string(),
+});
+
+const StatusPageAffectedComponentSchema = z.object({
+  code: z.string(),
+});
+
+const StatusPageIncidentUpdateSchema = z.object({
+  body: z.string(),
+  affected_components: z.array(StatusPageAffectedComponentSchema).optional(),
+});
+
+const StatusPageIncidentSchema = z.object({
+  name: z.string(),
+  impact: z.string(),
+  components: z.array(StatusPageComponentSchema).optional(),
+  incident_updates: z.array(StatusPageIncidentUpdateSchema).optional(),
+});
+
+const StatusPageSummarySchema = z.object({
+  page: z.object({
+    updated_at: z.string(),
+  }),
+  components: z.array(StatusPageComponentSchema),
+  incidents: z.array(StatusPageIncidentSchema),
+});
+
+export async function GET() {
+  try {
+    const response = await fetch(CLAUDE_STATUS_API, {
+      next: { revalidate: 300 },
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch Claude status");
+    }
+
+    const rawData = await response.json();
+    const data = StatusPageSummarySchema.parse(rawData);
+
+    // Find the Claude Code component
+    const claudeCode = data.components.find(
+      (c) => c.id === TARGET_COMPONENT_ID
+    );
+
+    const isDegraded = claudeCode && claudeCode.status !== "operational";
+
+    // Find relevant incidents
+    const relevantIncident = data.incidents.find(
+      (incident) =>
+        incident.components?.some((c) => c.id === TARGET_COMPONENT_ID) ||
+        incident.incident_updates?.some((update) =>
+          update.affected_components?.some(
+            (ac) => ac.code === TARGET_COMPONENT_ID
+          )
+        )
+    );
+
+    const latestUpdate = relevantIncident?.incident_updates?.[0]?.body;
+
+    return NextResponse.json({
+      isDegraded,
+      status: claudeCode?.status || "unknown",
+      incidentName: relevantIncident?.name || null,
+      message:
+        latestUpdate ||
+        (isDegraded ? "Claude Code is experiencing issues." : null),
+      impact: relevantIncident?.impact || null,
+      updatedAt: data.page.updated_at,
+    });
+  } catch (error) {
+    console.error("Claude Status Proxy Error:", error);
+    return NextResponse.json(
+      { isDegraded: false, error: "Status check unavailable" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/components/shell/LighthouseOverlay.tsx
+++ b/apps/web/src/components/shell/LighthouseOverlay.tsx
@@ -8,7 +8,7 @@ function lerp(start: number, end: number, factor: number): number {
   return start + (end - start) * factor;
 }
 
-function subscribeToTouchCapability(_callback: () => void): () => void {
+function subscribeToTouchCapability(): () => void {
   return () => {};
 }
 

--- a/apps/web/src/components/shell/NeuralDust.tsx
+++ b/apps/web/src/components/shell/NeuralDust.tsx
@@ -18,7 +18,7 @@ interface Particle {
   opacity: number;
 }
 
-function subscribeToTouchCapability(_callback: () => void): () => void {
+function subscribeToTouchCapability(): () => void {
   return () => {};
 }
 

--- a/apps/web/src/components/status/ClaudeStatusIndicator.tsx
+++ b/apps/web/src/components/status/ClaudeStatusIndicator.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import "client-only";
+
+import { AlertCircle, X } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogTitle,
+  MotionDialogContent,
+} from "@/components/ui/dialog";
+
+interface StatusData {
+  isDegraded: boolean;
+  status: string;
+  incidentName: string | null;
+  message: string | null;
+  impact: string | null;
+  updatedAt: string;
+}
+
+export function ClaudeStatusIndicator() {
+  const [data, setData] = useState<StatusData | null>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    async function checkStatus() {
+      try {
+        const res = await fetch("/api/claude-status");
+        if (res.ok) {
+          const json = await res.json();
+          setData(json);
+        }
+      } catch (err) {
+        console.error("Failed to fetch status", err);
+      }
+    }
+
+    checkStatus();
+    const interval = setInterval(checkStatus, 300000); // 5 mins
+    return () => clearInterval(interval);
+  }, []);
+
+  if (!data?.isDegraded) return null;
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="group fixed top-6 right-6 z-50 flex items-center gap-2"
+        aria-label="System status alert"
+      >
+        <span className="relative flex size-3">
+          <span className="bg-accent-warm absolute inline-flex h-full w-full animate-ping rounded-full opacity-75"></span>
+          <span className="bg-accent-warm relative inline-flex size-3 rounded-full shadow-[0_0_8px_oklch(70%_0.15_50_/_0.5)]"></span>
+        </span>
+        <span className="font-data text-accent-warm text-[10px] tracking-widest uppercase">
+          System Alert
+        </span>
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <MotionDialogContent
+          open={open}
+          className="sm:max-w-md"
+          showCloseButton={false}
+        >
+          <div className="mb-6 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="bg-accent-warm/10 rounded-full p-2">
+                <AlertCircle className="text-accent-warm size-5" />
+              </div>
+              <DialogTitle className="text-text-primary text-base font-medium">
+                Claude System Status
+              </DialogTitle>
+            </div>
+            <button
+              onClick={() => setOpen(false)}
+              className="text-text-tertiary hover:text-text-secondary transition-colors"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-text-secondary mb-1 text-xs font-medium tracking-wide uppercase">
+                Incident
+              </h3>
+              <p className="text-text-primary text-sm">
+                {data.incidentName || "Degraded Service"}
+              </p>
+            </div>
+
+            <div>
+              <h3 className="text-text-secondary mb-1 text-xs font-medium tracking-wide uppercase">
+                Details
+              </h3>
+              <p className="text-text-tertiary text-sm leading-relaxed">
+                {data.message}
+              </p>
+            </div>
+
+            <div className="border-border/40 flex items-center justify-between border-t pt-2">
+              <span className="font-data text-text-tertiary text-[10px] tracking-tighter uppercase">
+                Impact: {data.impact || "Minor"}
+              </span>
+              <span className="font-data text-text-tertiary text-[10px] tracking-tighter uppercase">
+                Updated:{" "}
+                {new Date(data.updatedAt).toLocaleTimeString([], {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </span>
+            </div>
+          </div>
+
+          <div className="mt-6 flex justify-end">
+            <Button variant="outline" size="sm" onClick={() => setOpen(false)}>
+              Acknowledge
+            </Button>
+          </div>
+        </MotionDialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Implement a conditional system status indicator that monitors the Claude Code component status via status.claude.com. The indicator is globally persistent but only visible during service degradation, providing a detailed incident modal on interaction.

## Test Plan

- [x] Unit tests pass
- [x] Lint passes
- [x] Type check passes
- [x] Build succeeds

## Mobile Responsiveness Evidence

N/A - Component is anchored top-right with fixed positioning, scales with standard viewport margins.

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers