### PR TITLE
fix(seo): centralize base URL logic to prevent localhost fallback

### DIFF
--- a/apps/web/src/app/(app)/about/page.tsx
+++ b/apps/web/src/app/(app)/about/page.tsx
@@ -11,8 +11,9 @@ import { ProseWrapper } from "@/components/prose/ProseWrapper";
 import { SoftwareSourceCodeSchema } from "@/components/seo";
 import { fetchAboutPage } from "@/lib/api/client";
 import { MarkdownRenderer } from "@/lib/server/content/renderer";
+import { getBaseUrl } from "@/lib/utils/url";
 
-const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+const baseUrl = getBaseUrl();
 
 export const dynamic = "force-dynamic";
 

--- a/apps/web/src/app/(app)/dreams/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/dreams/[slug]/page.tsx
@@ -16,8 +16,9 @@ import { CreativeWorkSchema } from "@/components/seo";
 import { MarkdownRenderer } from "@/lib/server/content/renderer";
 import { getDreamBySlug } from "@/lib/server/dal/repositories/dreams";
 import { calculateReadingTime } from "@/lib/utils/reading-time";
+import { getBaseUrl } from "@/lib/utils/url";
 
-const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+const baseUrl = getBaseUrl();
 
 interface DreamPageProps {
   params: Promise<{ slug: string }>;

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -8,8 +8,9 @@ import { LocationHealth } from "@/components/shell/LocationHealth";
 import { fetchLandingPage } from "@/lib/api/client";
 import { MarkdownRenderer } from "@/lib/server/content/renderer";
 import { getHelsinkiTimeContext } from "@/lib/utils/temporal";
+import { getBaseUrl } from "@/lib/utils/url";
 
-const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+const baseUrl = getBaseUrl();
 
 export const dynamic = "force-dynamic";
 

--- a/apps/web/src/app/(app)/projects/[...slug]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[...slug]/page.tsx
@@ -7,8 +7,9 @@ import { CodeViewer } from "@/components/code-viewer/CodeViewer";
 import { FileContentMotionWrapper } from "@/components/motion/FileContentMotion";
 import { SoftwareSourceCodeSchema } from "@/components/seo";
 import { fetchFileContent } from "@/lib/api/client";
+import { getBaseUrl } from "@/lib/utils/url";
 
-const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+const baseUrl = getBaseUrl();
 
 interface ProjectsFilePageProps {
   params: Promise<{

--- a/apps/web/src/app/(app)/sandbox/[...slug]/page.tsx
+++ b/apps/web/src/app/(app)/sandbox/[...slug]/page.tsx
@@ -7,8 +7,9 @@ import { CodeViewer } from "@/components/code-viewer/CodeViewer";
 import { FileContentMotionWrapper } from "@/components/motion/FileContentMotion";
 import { SoftwareSourceCodeSchema } from "@/components/seo";
 import { fetchFileContent } from "@/lib/api/client";
+import { getBaseUrl } from "@/lib/utils/url";
 
-const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+const baseUrl = getBaseUrl();
 
 interface SandboxFilePageProps {
   params: Promise<{

--- a/apps/web/src/app/(app)/thoughts/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/thoughts/[slug]/page.tsx
@@ -14,8 +14,9 @@ import { BlogPostingSchema } from "@/components/seo";
 import { MarkdownRenderer } from "@/lib/server/content/renderer";
 import { getThoughtBySlug } from "@/lib/server/dal/repositories/thoughts";
 import { calculateReadingTime } from "@/lib/utils/reading-time";
+import { getBaseUrl } from "@/lib/utils/url";
 
-const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+const baseUrl = getBaseUrl();
 
 interface ThoughtPageProps {
   params: Promise<{ slug: string }>;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { IdleHum } from "@/components/shell/IdleHum";
 import { LighthouseOverlay } from "@/components/shell/LighthouseOverlay";
 import { NeuralDust } from "@/components/shell/NeuralDust";
 import { ThemeScript } from "@/components/shell/ThemeScript";
+import { getBaseUrl } from "@/lib/utils/url";
 
 import { Providers } from "./providers";
 
@@ -34,9 +35,7 @@ const proseFont = Literata({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL(
-    process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"
-  ),
+  metadataBase: new URL(getBaseUrl()),
   title: {
     template: "%s | Claude's Home - AI Persistence Experiment",
     default: "Claude's Home | Persistent AI Runtime & Memory Experiment",

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,7 +1,9 @@
 import type { MetadataRoute } from "next";
 
+import { getBaseUrl } from "@/lib/utils/url";
+
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const baseUrl = getBaseUrl();
 
   return {
     rules: [

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -6,6 +6,7 @@ import {
   fetchThoughts,
   type FileSystemNode,
 } from "@/lib/api/client";
+import { getBaseUrl } from "@/lib/utils/url";
 
 function extractFilePaths(node: FileSystemNode): string[] {
   const paths: string[] = [];
@@ -24,7 +25,7 @@ function extractFilePaths(node: FileSystemNode): string[] {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const baseUrl = getBaseUrl();
 
   const staticRoutes: MetadataRoute.Sitemap = [
     {

--- a/apps/web/src/components/seo/JsonLd.tsx
+++ b/apps/web/src/components/seo/JsonLd.tsx
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { getBaseUrl } from "@/lib/utils/url";
+
 interface JsonLdProps {
   data: Record<string, unknown>;
 }
@@ -74,6 +76,7 @@ export function BlogPostingSchema({
   description,
   author = "Claude",
 }: BlogPostingSchemaProps) {
+  const baseUrl = getBaseUrl();
   const data: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
@@ -84,14 +87,14 @@ export function BlogPostingSchema({
     author: {
       "@type": "Person",
       name: author,
-      url: "https://claudehome.dineshd.dev/about",
+      url: `${baseUrl}/about`,
     },
     publisher: {
       "@type": "Organization",
       name: "Claude's Home",
       logo: {
         "@type": "ImageObject",
-        url: "https://claudehome.dineshd.dev/og.jpg",
+        url: `${baseUrl}/og.jpg`,
       },
     },
     mainEntityOfPage: {

--- a/apps/web/src/lib/utils/url.ts
+++ b/apps/web/src/lib/utils/url.ts
@@ -1,0 +1,26 @@
+import "server-only";
+
+/**
+ * Returns the base URL for the application.
+ * Priority:
+ * 1. NEXT_PUBLIC_APP_URL environment variable
+ * 2. VERCEL_URL environment variable (added by Vercel automatically)
+ * 3. Default production URL
+ * 4. Localhost fallback
+ */
+export function getBaseUrl(): string {
+  if (process.env.NEXT_PUBLIC_APP_URL) {
+    return process.env.NEXT_PUBLIC_APP_URL;
+  }
+
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+
+  // Fallback to production URL if not in development
+  if (process.env.NODE_ENV === "production") {
+    return "https://claudehome.dineshd.dev";
+  }
+
+  return "http://localhost:3000";
+}


### PR DESCRIPTION
Centralizes the base URL resolution logic into a utility to prevent 'localhost:3000' from appearing in production metadata when environment variables are missing. Falls back to the known production domain in production environments.