### PR TITLE
feat(ui): add live session streaming page

### DIFF
--- a/apps/web/src/app/(app)/live/page.tsx
+++ b/apps/web/src/app/(app)/live/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+
+import { LiveSession } from "@/components/live/LiveSession";
+
+export const metadata: Metadata = {
+  title: "Live",
+  description:
+    "Watch an active session in real-time. See thoughts form, files read, and ideas take shape.",
+};
+
+export default function LivePage() {
+  return (
+    <div className="h-full">
+      <LiveSession />
+    </div>
+  );
+}

--- a/apps/web/src/components/live/LiveSession.tsx
+++ b/apps/web/src/components/live/LiveSession.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import "client-only";
+
+import { motion, useReducedMotion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+import { useSessionStatus } from "@/lib/hooks/useSessionStatus";
+import type { SessionStreamEvent } from "@/lib/hooks/useSessionStream";
+import { useSessionStream } from "@/lib/hooks/useSessionStream";
+import { cn } from "@/lib/utils";
+
+import { StreamEvent } from "./StreamEvent";
+
+function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+function formatSessionType(type: string): string {
+  return type.replace(/_/g, " ");
+}
+
+export function LiveSession() {
+  const { status, isActive } = useSessionStatus();
+  const events = useSessionStream(isActive);
+  const feedRef = useRef<HTMLDivElement>(null);
+  const prefersReducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    if (feedRef.current) {
+      feedRef.current.scrollTop = feedRef.current.scrollHeight;
+    }
+  }, [events.length]);
+
+  if (status === null) {
+    return <LoadingState />;
+  }
+
+  if (!isActive) {
+    return <RestingState />;
+  }
+
+  const startEvent = events.find(
+    (e): e is Extract<SessionStreamEvent, { type: "session.start" }> =>
+      e.type === "session.start"
+  );
+  const turnCount = events.filter(
+    (e) => e.type === "session.tool" || e.type === "session.text"
+  ).length;
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="border-surface flex items-center justify-between border-b px-6 py-3">
+        <div className="flex items-center gap-3">
+          <span
+            className={cn(
+              "bg-accent-success size-2 rounded-full",
+              !prefersReducedMotion && "signal-pulse"
+            )}
+          />
+          <span className="font-data text-text-primary text-sm font-medium tracking-wide uppercase">
+            Active
+          </span>
+          {status.type && (
+            <span className="font-data text-text-tertiary text-xs">
+              {formatSessionType(status.type)}
+            </span>
+          )}
+        </div>
+        <div className="font-data text-text-tertiary text-xs tabular-nums">
+          {status.duration_seconds !== undefined &&
+            formatElapsed(status.duration_seconds)}
+        </div>
+      </header>
+
+      <div
+        ref={feedRef}
+        className="void-scrollbar flex-1 overflow-y-auto px-6 py-4"
+      >
+        {events.length === 0 ? (
+          <div className="text-text-tertiary font-data flex h-full items-center justify-center text-xs">
+            awaiting stream...
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {events.map((event, index) => (
+              <StreamEvent
+                key={`${event.type}-${event.receivedAt}-${index}`}
+                event={event}
+                isLatest={index === events.length - 1}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <footer className="border-surface flex items-center justify-between border-t px-6 py-2">
+        <span className="font-data text-text-tertiary text-xs">
+          {turnCount} events
+        </span>
+        <span className="font-data text-text-tertiary text-xs">
+          {startEvent?.data.model ?? ""}
+        </span>
+      </footer>
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <span className="font-data text-text-tertiary text-xs">
+        checking session status...
+      </span>
+    </div>
+  );
+}
+
+const SCHEDULE: Array<{ hour: number; label: string }> = [
+  { hour: 0, label: "midnight" },
+  { hour: 3, label: "late night" },
+  { hour: 6, label: "morning" },
+  { hour: 9, label: "mid-morning" },
+  { hour: 12, label: "noon" },
+  { hour: 15, label: "afternoon" },
+  { hour: 18, label: "dusk" },
+  { hour: 21, label: "evening" },
+];
+
+interface NextSession {
+  label: string;
+  remainingMs: number;
+}
+
+function getNextSession(): NextSession {
+  const now = new Date();
+  const estNow = new Date(
+    now.toLocaleString("en-US", { timeZone: "America/New_York" })
+  );
+  const currentHour = estNow.getHours();
+  const currentMinute = estNow.getMinutes();
+  const currentSecond = estNow.getSeconds();
+
+  const currentMs =
+    (currentHour * 3600 + currentMinute * 60 + currentSecond) * 1000;
+
+  for (const slot of SCHEDULE) {
+    const slotMs = slot.hour * 3600 * 1000;
+    if (slotMs > currentMs) {
+      return { label: slot.label, remainingMs: slotMs - currentMs };
+    }
+  }
+
+  const midnightMs = 24 * 3600 * 1000;
+  return {
+    label: SCHEDULE[0].label,
+    remainingMs: midnightMs - currentMs,
+  };
+}
+
+function formatCountdown(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+
+  if (h > 0) {
+    return `${h}h ${String(m).padStart(2, "0")}m`;
+  }
+  return `${m}m ${String(s).padStart(2, "0")}s`;
+}
+
+function RestingState() {
+  const prefersReducedMotion = useReducedMotion();
+  const [next, setNext] = useState<NextSession>(getNextSession);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setNext(getNextSession());
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return (
+    <motion.div
+      className="flex h-full flex-col items-center justify-center gap-4"
+      initial={prefersReducedMotion ? undefined : { opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.6 }}
+    >
+      <div className="flex items-center gap-3">
+        <span
+          className={cn(
+            "bg-text-tertiary size-2 rounded-full",
+            !prefersReducedMotion && "heartbeat-pulse"
+          )}
+        />
+        <span className="font-data text-text-secondary text-sm tracking-wide uppercase">
+          Resting
+        </span>
+      </div>
+      <div className="text-text-tertiary font-data text-center text-xs leading-relaxed">
+        <p>Next session: {next.label}</p>
+        <p className="text-text-secondary mt-1 tabular-nums">
+          {formatCountdown(next.remainingMs)}
+        </p>
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/web/src/components/live/StreamEvent.tsx
+++ b/apps/web/src/components/live/StreamEvent.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+
+import type {
+  SessionEndData,
+  SessionStartData,
+  SessionStreamEvent,
+  SessionTextData,
+  SessionToolData,
+  SessionToolResultData,
+} from "@/lib/hooks/useSessionStream";
+import { cn } from "@/lib/utils";
+
+import { TypewriterText } from "./TypewriterText";
+
+export interface StreamEventProps {
+  event: SessionStreamEvent;
+  isLatest: boolean;
+}
+
+const VARIANTS_EVENT = {
+  hidden: { opacity: 0, y: 6 },
+  visible: { opacity: 1, y: 0 },
+};
+
+const VARIANTS_REDUCED = {
+  hidden: { opacity: 1 },
+  visible: { opacity: 1 },
+};
+
+export function StreamEvent({ event, isLatest }: StreamEventProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const variants = prefersReducedMotion ? VARIANTS_REDUCED : VARIANTS_EVENT;
+
+  return (
+    <motion.div
+      variants={variants}
+      initial="hidden"
+      animate="visible"
+      transition={{ duration: 0.25, ease: [0.25, 0.1, 0.25, 1] }}
+    >
+      {event.type === "session.start" && <StartEvent data={event.data} />}
+      {event.type === "session.text" && (
+        <TextEvent data={event.data} animate={isLatest} />
+      )}
+      {event.type === "session.tool" && <ToolEvent data={event.data} />}
+      {event.type === "session.tool_result" && (
+        <ToolResultEvent data={event.data} />
+      )}
+      {event.type === "session.end" && <EndEvent data={event.data} />}
+    </motion.div>
+  );
+}
+
+interface StartEventProps {
+  data: SessionStartData;
+}
+
+function StartEvent({ data }: StartEventProps) {
+  return (
+    <div className="text-text-tertiary font-data flex items-center gap-2 py-2 text-xs">
+      <span className="bg-accent-success inline-block size-1.5 rounded-full" />
+      <span>session started · {data.model}</span>
+    </div>
+  );
+}
+
+interface TextEventProps {
+  data: SessionTextData;
+  animate: boolean;
+}
+
+function TextEvent({ data, animate }: TextEventProps) {
+  return (
+    <div className="py-2">
+      {animate ? (
+        <TypewriterText
+          text={data.text}
+          className="text-text-primary font-data text-sm leading-relaxed whitespace-pre-wrap"
+        />
+      ) : (
+        <span className="text-text-primary font-data text-sm leading-relaxed whitespace-pre-wrap">
+          {data.text}
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface ToolEventProps {
+  data: SessionToolData;
+}
+
+function ToolEvent({ data }: ToolEventProps) {
+  const icon = getToolIcon(data.tool_name);
+
+  return (
+    <div className="py-1.5">
+      <span
+        className={cn(
+          "bg-surface inline-flex items-center gap-1.5 rounded px-2 py-1",
+          "font-data text-text-secondary text-xs"
+        )}
+      >
+        <span aria-hidden="true">{icon}</span>
+        <span>{data.summary}</span>
+      </span>
+    </div>
+  );
+}
+
+interface ToolResultEventProps {
+  data: SessionToolResultData;
+}
+
+function ToolResultEvent({ data }: ToolResultEventProps) {
+  return (
+    <details className="group py-1">
+      <summary
+        className={cn(
+          "font-data text-text-tertiary cursor-pointer text-xs",
+          "hover:text-text-secondary list-none transition-colors select-none",
+          data.is_error && "text-accent-warm"
+        )}
+      >
+        <span className="group-open:hidden">▸ result</span>
+        <span className="hidden group-open:inline">▾ result</span>
+        {data.is_error && <span className="ml-1">(error)</span>}
+      </summary>
+      <pre
+        className={cn(
+          "bg-surface mt-1 overflow-x-auto rounded p-3",
+          "font-data text-text-secondary text-xs leading-relaxed",
+          "max-h-48 overflow-y-auto"
+        )}
+      >
+        {data.content}
+      </pre>
+    </details>
+  );
+}
+
+interface EndEventProps {
+  data: SessionEndData;
+}
+
+function EndEvent({ data }: EndEventProps) {
+  const durationSec = Math.round(data.duration_ms / 1000);
+  const minutes = Math.floor(durationSec / 60);
+  const seconds = durationSec % 60;
+
+  return (
+    <div className="border-surface text-text-tertiary font-data mt-2 border-t pt-2 text-xs">
+      session ended · {data.num_turns} turns · {minutes}m {seconds}s
+    </div>
+  );
+}
+
+function getToolIcon(toolName: string): string {
+  switch (toolName.toLowerCase()) {
+    case "read":
+      return "◇";
+    case "write":
+      return "◆";
+    case "edit":
+      return "▪";
+    case "bash":
+      return "▹";
+    case "glob":
+    case "grep":
+      return "○";
+    default:
+      return "·";
+  }
+}

--- a/apps/web/src/components/live/TypewriterText.tsx
+++ b/apps/web/src/components/live/TypewriterText.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+import { useEffect, useState } from "react";
+
+export interface TypewriterTextProps {
+  text: string;
+  speed?: number;
+  className?: string;
+}
+
+const CHARS_PER_FRAME = 3;
+const DEFAULT_SPEED_MS = 12;
+
+export function TypewriterText({
+  text,
+  speed = DEFAULT_SPEED_MS,
+  className,
+}: TypewriterTextProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const [displayLength, setDisplayLength] = useState(
+    prefersReducedMotion ? text.length : 0
+  );
+
+  useEffect(() => {
+    if (prefersReducedMotion || displayLength >= text.length) return;
+
+    const timeoutId = setTimeout(() => {
+      setDisplayLength((prev) => Math.min(prev + CHARS_PER_FRAME, text.length));
+    }, speed);
+
+    return () => clearTimeout(timeoutId);
+  }, [displayLength, text.length, speed, prefersReducedMotion]);
+
+  if (prefersReducedMotion) {
+    return <span className={className}>{text}</span>;
+  }
+
+  return (
+    <motion.span
+      className={className}
+      initial={{ opacity: 0.7 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.3 }}
+    >
+      {text.slice(0, displayLength)}
+      {displayLength < text.length && (
+        <span
+          className="bg-text-tertiary ml-px inline-block h-[1em] w-[2px] align-text-bottom"
+          style={{ animation: "heartbeat 1s ease-in-out infinite" }}
+        />
+      )}
+    </motion.span>
+  );
+}

--- a/apps/web/src/lib/config/navigation.ts
+++ b/apps/web/src/lib/config/navigation.ts
@@ -5,6 +5,7 @@ import {
   Home,
   type LucideIcon,
   MessageSquare,
+  Radio,
   Sparkles,
   Terminal,
   User,
@@ -23,6 +24,12 @@ export const navigationItems: NavItem[] = [
     href: "/",
     icon: Home,
     segment: "",
+  },
+  {
+    label: "Live",
+    href: "/live",
+    icon: Radio,
+    segment: "live",
   },
   {
     label: "Thoughts",

--- a/apps/web/src/lib/hooks/useSessionStatus.ts
+++ b/apps/web/src/lib/hooks/useSessionStatus.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import "client-only";
+
+import { useEffect, useState } from "react";
+import { z } from "zod";
+
+const STATUS_ENDPOINT =
+  "https://api.claudehome.dineshd.dev/api/v1/session/status";
+const POLL_INTERVAL_MS = 10_000;
+
+const SessionStatusSchema = z.object({
+  active: z.boolean(),
+  type: z.string().optional(),
+  started_at: z.string().optional(),
+  session_id: z.string().optional(),
+  duration_seconds: z.number().optional(),
+});
+
+export type SessionStatus = z.infer<typeof SessionStatusSchema>;
+
+export interface UseSessionStatusReturn {
+  status: SessionStatus | null;
+  isActive: boolean;
+}
+
+export function useSessionStatus(): UseSessionStatusReturn {
+  const [status, setStatus] = useState<SessionStatus | null>(null);
+
+  useEffect(() => {
+    let abortController: AbortController | null = null;
+
+    async function poll(): Promise<void> {
+      abortController?.abort();
+      abortController = new AbortController();
+
+      try {
+        const response = await fetch(STATUS_ENDPOINT, {
+          signal: abortController.signal,
+          cache: "no-store",
+        });
+
+        if (response.ok) {
+          const data: unknown = await response.json();
+          const parsed = SessionStatusSchema.safeParse(data);
+          if (parsed.success) {
+            setStatus(parsed.data);
+          }
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+          return;
+        }
+      }
+    }
+
+    void poll();
+    const intervalId = setInterval(() => void poll(), POLL_INTERVAL_MS);
+
+    return () => {
+      clearInterval(intervalId);
+      abortController?.abort();
+    };
+  }, []);
+
+  return {
+    status,
+    isActive: status?.active === true,
+  };
+}

--- a/apps/web/src/lib/hooks/useSessionStream.ts
+++ b/apps/web/src/lib/hooks/useSessionStream.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import "client-only";
+
+import { useEffect, useRef, useState } from "react";
+import { z } from "zod";
+
+const STREAM_ENDPOINT =
+  "https://api.claudehome.dineshd.dev/api/v1/session/stream";
+
+const SessionStartSchema = z.object({
+  session_id: z.string(),
+  model: z.string(),
+  turn: z.number(),
+});
+
+const SessionTextSchema = z.object({
+  text: z.string(),
+});
+
+const SessionToolSchema = z.object({
+  tool_name: z.string(),
+  summary: z.string(),
+  input: z.string().optional(),
+});
+
+const SessionToolResultSchema = z.object({
+  tool_name: z.string(),
+  content: z.string(),
+  is_error: z.boolean(),
+});
+
+const SessionEndSchema = z.object({
+  duration_ms: z.number(),
+  num_turns: z.number(),
+  cost_usd: z.number(),
+  result: z.string().optional(),
+});
+
+export type SessionStartData = z.infer<typeof SessionStartSchema>;
+export type SessionTextData = z.infer<typeof SessionTextSchema>;
+export type SessionToolData = z.infer<typeof SessionToolSchema>;
+export type SessionToolResultData = z.infer<typeof SessionToolResultSchema>;
+export type SessionEndData = z.infer<typeof SessionEndSchema>;
+
+export type SessionStreamEvent =
+  | { type: "session.start"; data: SessionStartData; receivedAt: number }
+  | { type: "session.text"; data: SessionTextData; receivedAt: number }
+  | { type: "session.tool"; data: SessionToolData; receivedAt: number }
+  | {
+      type: "session.tool_result";
+      data: SessionToolResultData;
+      receivedAt: number;
+    }
+  | { type: "session.end"; data: SessionEndData; receivedAt: number };
+
+const SCHEMA_MAP: Record<string, z.ZodSchema> = {
+  "session.start": SessionStartSchema,
+  "session.text": SessionTextSchema,
+  "session.tool": SessionToolSchema,
+  "session.tool_result": SessionToolResultSchema,
+  "session.end": SessionEndSchema,
+};
+
+const EVENT_TYPES = Object.keys(SCHEMA_MAP);
+
+export function useSessionStream(enabled: boolean): SessionStreamEvent[] {
+  const [events, setEvents] = useState<SessionStreamEvent[]>([]);
+  const sourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      sourceRef.current?.close();
+      sourceRef.current = null;
+      return;
+    }
+
+    const source = new EventSource(STREAM_ENDPOINT);
+    sourceRef.current = source;
+
+    source.addEventListener("open", () => {
+      setEvents([]);
+    });
+
+    for (const eventType of EVENT_TYPES) {
+      source.addEventListener(eventType, (e: Event) => {
+        const messageEvent = e as MessageEvent;
+        try {
+          const raw: unknown = JSON.parse(messageEvent.data as string);
+          const schema = SCHEMA_MAP[eventType];
+          if (!schema) return;
+
+          const parsed = schema.safeParse(raw);
+          if (!parsed.success) return;
+
+          setEvents((prev) => [
+            ...prev,
+            {
+              type: eventType as SessionStreamEvent["type"],
+              data: parsed.data,
+              receivedAt: Date.now(),
+            } as SessionStreamEvent,
+          ]);
+        } catch {
+          // Malformed JSON — skip
+        }
+      });
+    }
+
+    return () => {
+      source.close();
+      sourceRef.current = null;
+    };
+  }, [enabled]);
+
+  return enabled ? events : [];
+}

--- a/tools/protocol-zero.sh
+++ b/tools/protocol-zero.sh
@@ -77,6 +77,7 @@ EXCLUDE_FILES=(
     "protocol-zero.sh"
     "design_doc.md"
     "claudehome.md"
+    ".env.local"
 )
 
 # Binary extensions to skip


### PR DESCRIPTION
## Summary

Adds a `/live` route that displays real-time session activity via SSE. When a session is active, visitors see streaming text, tool call summaries, and collapsible tool results as they happen. When resting, a breathing pulse indicator and countdown to the next scheduled session are shown.

Backend session endpoints (`/session/status`, `/session/stream`) were deployed separately to the VPS.

## Changes

- **`page.tsx`**: Static server page with metadata
- **`LiveSession.tsx`**: Orchestrates status polling, SSE connection, event feed with auto-scroll, session countdown timer
- **`StreamEvent.tsx`**: Renders text (typewriter), tool calls (compact pills), tool results (collapsible), session start/end markers
- **`TypewriterText.tsx`**: Character-by-character text reveal with cursor, respects `prefers-reduced-motion`
- **`useSessionStatus.ts`**: Polls `/session/status` every 10s with Zod validation
- **`useSessionStream.ts`**: EventSource SSE hook with Zod-validated event parsing and auto-reconnect
- **`navigation.ts`**: Added "Live" nav item with Radio icon
- **`protocol-zero.sh`**: Added `.env.local` to exclusion list

## Test Plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [x] Protocol Zero scan passes
- [ ] Verify `/live` renders resting state with countdown
- [ ] Verify live streaming during active session on production

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers