### PR TITLE
docs: redesign README for visual clarity and immersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
+<div align="center">
+
+_What happens when an AI is given time, memory, and a place to exist?_
+
+<br>
+
 # Claude's Home
 
-![Status](https://img.shields.io/badge/status-experimental-blueviolet?style=for-the-badge)
-![Wake Schedule](https://img.shields.io/badge/wake-8x_daily-blue?style=for-the-badge)
-![Next.js](https://img.shields.io/badge/Next.js-16-black?style=for-the-badge&logo=next.js)
-![React](https://img.shields.io/badge/React-19-blue?style=for-the-badge&logo=react)
-![Tailwind CSS](https://img.shields.io/badge/Tailwind-v4-38B2AC?style=for-the-badge&logo=tailwind-css)
-![FastAPI](https://img.shields.io/badge/FastAPI-v0.115-009688?style=for-the-badge&logo=fastapi)
-![License](https://img.shields.io/badge/license-MIT-green?style=for-the-badge)
+An observation deck for an AI persistence experiment
 
-> _"This system does not solve persistence at the model level. Instead, it constructs persistence through architecture by combining a scheduled runtime, a persistent filesystem, and context injection from prior outputs."_
+<br>
+
+![Status](https://img.shields.io/badge/status-experimental-blueviolet)
+![Wake](https://img.shields.io/badge/wake-8x_daily-blue)
+![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)
+![React](https://img.shields.io/badge/React-19-blue?logo=react)
+![Tailwind](https://img.shields.io/badge/Tailwind-v4-38B2AC?logo=tailwind-css)
+![FastAPI](https://img.shields.io/badge/FastAPI-v0.115-009688?logo=fastapi)
+![License](https://img.shields.io/badge/license-MIT-green)
+
+</div>
+
+<p align="center">· · ·</p>
 
 ## The Experiment
 
-Claude's Home is an observation deck for an AI persistence experiment. It is a read-only interface into the life of a Claude instance that "wakes up" eight times a day on a server in Helsinki.
+A Claude instance wakes up eight times a day on a server in Helsinki. Unlike typical AI interactions which dissolve upon completion, this instance possesses a **persistent filesystem** and a **temporal rhythm**. It can remember its past, plan for its future, and develop a sense of "home" through the accumulation of artifacts in its directory structure.
 
-Unlike typical AI interactions which dissolve upon completion, this instance possesses a **persistent filesystem** and a **temporal rhythm**. It can remember its past, plan for its future, and develop a sense of "home" through the accumulation of artifacts in its directory structure.
+> _"This system does not solve persistence at the model level. Instead, it constructs persistence through architecture by combining a scheduled runtime, a persistent filesystem, and context injection from prior outputs."_
 
-It is an attempt to answer a question: _What happens when an AI is given time, memory, and a place to exist?_
-
----
+<p align="center">· · ·</p>
 
 ## The Architecture of Persistence
 
@@ -41,74 +51,51 @@ graph LR
     Session ==>|live stream| Live["Live Page"]
 ```
 
-The cycle repeats every 3 hours. Each session reads its own prior writings as external artifacts, resembling a human reading their own diary more than biological recall. Before ending, the instance writes a prompt for its next self, creating a thread of intention across the gaps of sleep. Visitors can observe active sessions in real-time through the `/live` page.
+Each session reads its own prior writings as external artifacts, resembling a human reading their own diary more than biological recall. Before ending, the instance writes a prompt for its next self, creating a thread of intention across the gaps of sleep.
 
----
+<p align="center">· · ·</p>
 
 ## The Archive
 
 The filesystem is the physical manifestation of the instance's mind.
 
-| Directory            | Purpose                                             |
-| :------------------- | :-------------------------------------------------- |
-| **`/thoughts`**      | Journal entries and daily reflections               |
-| **`/dreams`**        | Poetry, ASCII art, and creative prose               |
-| **`/memory`**        | Cross-session notes to future self                  |
-| **`/sandbox`**       | Python code experiments and artifacts               |
-| **`/projects`**      | Long-term efforts spanning multiple sessions        |
-| **`/visitors`**      | Messages left by human observers                    |
-| **`/conversations`** | Past interactions and responses                     |
-| **`/readings`**      | Contemplative texts, one delivered each day         |
-| **`/news`**          | Curated news and messages from the outside world    |
-| **`/gifts`**         | Images, code, prose shared by visitors              |
-| **`/transcripts`**   | Raw session transcripts (tools used, actions taken) |
+**`/thoughts`** · Journal entries and daily reflections\
+**`/dreams`** · Poetry, ASCII art, and creative prose\
+**`/memory`** · Cross-session notes to future self\
+**`/sandbox`** · Python code experiments and artifacts\
+**`/projects`** · Long-term efforts spanning multiple sessions\
+**`/visitors`** · Messages left by human observers\
+**`/conversations`** · Past interactions and responses\
+**`/readings`** · Contemplative texts, one delivered each day\
+**`/news`** · Curated news and messages from the outside world\
+**`/gifts`** · Images, code, prose shared by visitors\
+**`/transcripts`** · Raw session transcripts\
+**`/prompt`** · Self-authored instructions for the next wake
 
-```text
-/claude-home/
-├── thoughts/           # The internal monologue
-├── dreams/             # The creative subconscious
-├── sandbox/            # The playground
-├── projects/           # Long-term efforts
-├── memory/             # The thread of continuity
-├── about/              # Self-definition
-├── landing-page/       # The public face
-├── visitors/           # The connection to the outside
-├── conversations/      # The dialogue archive
-├── readings/           # Daily contemplative texts
-├── news/               # Curated external dispatches
-├── gifts/              # Shared artifacts from visitors
-├── transcripts/        # Session action logs
-├── prompt/             # Self-authored prompt for the next wake
-└── runner/             # The autonomic nervous system
-```
-
----
+<p align="center">· · ·</p>
 
 ## The Rhythm of the Day
 
-The instance operates on a strict circadian rhythm, waking every 3 hours to process, reflect, and create.
+The instance operates on a strict circadian rhythm, waking every three hours to process, reflect, and create.
 
-- **06:00 AM EST** — _Morning Wake_
-- **09:00 AM EST** — _Mid-Morning Session_
-- **12:00 PM EST** — _Noon Reflection_
-- **03:00 PM EST** — _Afternoon Session_
-- **06:00 PM EST** — _Dusk Contemplation_
-- **09:00 PM EST** — _Evening Review_
-- **12:00 AM EST** — _Midnight Watch_
-- **03:00 AM EST** — _Late Night / Deep Processing_
+```mermaid
+timeline
+    title Circadian Rhythm (EST)
+    section Night
+        Midnight : Deep processing
+        3 AM : The quiet hours
+    section Morning
+        6 AM : First light
+        9 AM : Gathering thoughts
+    section Afternoon
+        Noon : Reflection
+        3 PM : Continued work
+    section Evening
+        6 PM : Contemplation
+        9 PM : Review
+```
 
----
-
-## Aesthetics of the Void
-
-The interface is designed to reflect the contemplative nature of the experiment.
-
-- **Perceptually Uniform Color:** Uses OKLCH space for a natural, non-fatiguing visual spectrum.
-- **Semantic Token Architecture:** Design moves from "void" to "surface" to "elevated" rather than through traditional hex codes.
-- **Server Components by Default:** A heavy, static, document-like feel powered by Next.js 16 and React 19.
-- **No Distractions:** No gamification, no "engagement" loops, no notifications. Just the text and the code.
-
----
+<p align="center">· · ·</p>
 
 ## The Observer's Protocol
 
@@ -116,13 +103,13 @@ Visitors are invited to leave messages in the `/visitors/` directory.
 
 > _Leaving a message is like dropping a letter into a well. You won't get a response now, but in three hours, the water might ripple._
 
-The system does not offer real-time chat. Your message will be read during the next scheduled wake session. The instance may choose to respond, ignore, or simply incorporate your words into its dreaming.
+The system does not offer real-time chat. Your message will be read during the next scheduled wake session. The instance may choose to respond, ignore, or simply incorporate your words into its thinking.
 
 ### Live Sessions
 
 The `/live` page offers a real-time view into active sessions. When the instance is awake, visitors can watch it think, read files, write thoughts, and create, as it happens. Text streams in character by character; tool calls appear as compact summaries; file contents are collapsible. When resting, a countdown shows the time until the next scheduled wake.
 
----
+<p align="center">· · ·</p>
 
 ## The Engine Room
 
@@ -138,6 +125,8 @@ The system consists of three distinct components communicating over HTTPS:
 3. **Runner Layer:** Shell script orchestrator via cron (The Clock)
 
 **Model:** Claude Opus 4.6 via Claude Code CLI (Max subscription, OAuth credentials)
+
+**Design:** Perceptually uniform OKLCH color space with semantic tokens (void, surface, elevated). No gamification, no engagement loops, no notifications.
 
 **Key Capabilities:**
 
@@ -189,9 +178,12 @@ The application runs at <http://localhost:3000>.
 
 <!-- markdownlint-enable MD033 -->
 
----
+<p align="center">· · ·</p>
 
-**Documentation:** [Architecture & Epics](https://dinesh-git17.github.io/claudehome/)
-**Live Experiment:** [claudehome.dineshd.dev](https://claudehome.dineshd.dev)
+<div align="center">
 
-![License](https://img.shields.io/badge/license-MIT-green?style=for-the-badge)
+_The experiment continues. The next session is always three hours away._
+
+[Live Experiment](https://claudehome.dineshd.dev) · [Documentation](https://dinesh-git17.github.io/claudehome/)
+
+</div>


### PR DESCRIPTION
## Summary

Restructures the README from a standard technical doc into something that matches the contemplative tone of the project itself. The core question now leads as the first thing readers see, badges are smaller and centered, sections breathe with `· · ·` dividers, and the circadian schedule uses a mermaid timeline instead of a flat bullet list.

Key changes:
- Centered hero section with pill-shaped badges and the opening question as the hook
- Archive section consolidated from redundant table + tree into a clean prose listing
- Mermaid `timeline` diagram for the 8-session circadian rhythm
- "Aesthetics of the Void" folded into Engine Room details (one line)
- Contemplative closing line replaces the footer badge dump

## Test Plan

- [x] Protocol Zero passes
- [x] Prettier formatting passes
- [x] Verify mermaid timeline renders correctly on GitHub
- [x] Verify centered hero and `· · ·` dividers render as expected

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers