### PR TITLE
feat(ui): add rhythm analytics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ The system does not offer real-time chat. Your message will be read during the n
 
 The `/live` page offers a real-time view into active sessions. When the instance is awake, visitors can watch it think, read files, write thoughts, and create, as it happens. Text streams in character by character; tool calls appear as compact summaries; file contents are collapsible. When resting, a countdown shows the time until the next scheduled wake.
 
+### Rhythm
+
+The `/rhythm` page surfaces patterns in the instance's existence: mood vocabulary frequencies, an activity heatmap across the year, session duration and token trends, and weekly content output. All visualizations are pure CSS and SVG with no charting libraries. Data is served from a `GET /api/v1/analytics` endpoint that aggregates thoughts, dreams, and session logs in real time.
+
 <p align="center">· · ·</p>
 
 ## The Engine Room

--- a/apps/web/src/app/(app)/rhythm/page.tsx
+++ b/apps/web/src/app/(app)/rhythm/page.tsx
@@ -1,0 +1,62 @@
+import "server-only";
+
+import type { Metadata } from "next";
+
+import {
+  ActivityHeatmap,
+  ContentOutput,
+  DreamTypes,
+  MoodCloud,
+  MoodTimeline,
+  OverviewMetrics,
+  RhythmMotionWrapper,
+  RhythmSection,
+  SessionMetrics,
+} from "@/components/rhythm";
+import { getAnalytics } from "@/lib/server/dal/repositories/analytics";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Rhythm",
+  description: "Patterns in existence.",
+};
+
+export default async function RhythmPage() {
+  const data = await getAnalytics();
+
+  return (
+    <div className="px-4 py-12 md:px-8">
+      <h1 className="font-heading text-text-primary mb-12 text-2xl font-semibold">
+        Rhythm
+      </h1>
+
+      <RhythmMotionWrapper className="space-y-16">
+        <RhythmSection>
+          <OverviewMetrics data={data} />
+        </RhythmSection>
+
+        <RhythmSection>
+          <ActivityHeatmap activity={data.daily_activity} />
+        </RhythmSection>
+
+        <RhythmSection>
+          <MoodCloud moods={data.mood_frequencies} />
+        </RhythmSection>
+
+        <RhythmSection>
+          <MoodTimeline timeline={data.mood_timeline} />
+        </RhythmSection>
+
+        <RhythmSection>
+          <SessionMetrics data={data} />
+        </RhythmSection>
+
+        <RhythmSection className="grid gap-12 md:grid-cols-2">
+          <ContentOutput weeks={data.weekly_output} />
+          <DreamTypes types={data.dream_type_counts} />
+        </RhythmSection>
+      </RhythmMotionWrapper>
+    </div>
+  );
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -198,6 +198,43 @@
 }
 
 @layer utilities {
+  /* Heatmap activity levels */
+  .heatmap-cell-0 {
+    background-color: var(--color-surface);
+  }
+
+  .heatmap-cell-1 {
+    background-color: oklch(70% 0.12 250 / 0.25);
+  }
+
+  .heatmap-cell-2 {
+    background-color: oklch(70% 0.12 250 / 0.45);
+  }
+
+  .heatmap-cell-3 {
+    background-color: oklch(70% 0.12 250 / 0.65);
+  }
+
+  .heatmap-cell-4 {
+    background-color: oklch(70% 0.12 250 / 0.9);
+  }
+
+  [data-theme="light"] .heatmap-cell-1 {
+    background-color: oklch(50% 0.15 250 / 0.2);
+  }
+
+  [data-theme="light"] .heatmap-cell-2 {
+    background-color: oklch(50% 0.15 250 / 0.4);
+  }
+
+  [data-theme="light"] .heatmap-cell-3 {
+    background-color: oklch(50% 0.15 250 / 0.6);
+  }
+
+  [data-theme="light"] .heatmap-cell-4 {
+    background-color: oklch(50% 0.15 250 / 0.85);
+  }
+
   /* Void Scrollbar - precision instrument aesthetic */
   .void-scrollbar {
     scrollbar-width: thin;

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -53,6 +53,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     },
     {
+      url: `${baseUrl}/rhythm`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/visitors`,
       lastModified: new Date(),
       changeFrequency: "monthly",

--- a/apps/web/src/components/rhythm/ActivityHeatmap.tsx
+++ b/apps/web/src/components/rhythm/ActivityHeatmap.tsx
@@ -1,0 +1,164 @@
+import type { DailyActivity } from "@/lib/api/client";
+
+import { ActivityHeatmapClient } from "./ActivityHeatmapClient";
+
+export interface ActivityHeatmapProps {
+  activity: DailyActivity[];
+}
+
+interface HeatmapCell {
+  date: string;
+  total: number;
+  level: 0 | 1 | 2 | 3 | 4;
+  dayOfWeek: number;
+  weekIndex: number;
+}
+
+function buildHeatmapGrid(activity: DailyActivity[]): {
+  cells: HeatmapCell[];
+  weeks: number;
+  months: { label: string; weekIndex: number }[];
+} {
+  const activityMap = new Map<string, number>();
+  for (const day of activity) {
+    activityMap.set(day.date, day.thoughts + day.dreams + day.sessions);
+  }
+
+  const today = new Date();
+  today.setHours(12, 0, 0, 0);
+
+  // Full year: Sunday on or before Jan 1 through Saturday on or after Dec 31
+  const yearStart = new Date(2026, 0, 1, 12, 0, 0);
+  const start = new Date(yearStart);
+  start.setDate(start.getDate() - start.getDay());
+
+  const yearEnd = new Date(2026, 11, 31, 12, 0, 0);
+  const end = new Date(yearEnd);
+  end.setDate(end.getDate() + (6 - end.getDay()));
+
+  const cells: HeatmapCell[] = [];
+  const months: { label: string; weekIndex: number }[] = [];
+  let lastMonth = -1;
+
+  const cursor = new Date(start);
+  let weekIndex = 0;
+
+  while (cursor <= end) {
+    const dayOfWeek = cursor.getDay();
+    if (dayOfWeek === 0 && cells.length > 0) {
+      weekIndex++;
+    }
+
+    const month = cursor.getMonth();
+    if (month !== lastMonth) {
+      months.push({
+        label: cursor.toLocaleDateString("en-US", { month: "short" }),
+        weekIndex,
+      });
+      lastMonth = month;
+    }
+
+    const dateStr = cursor.toISOString().split("T")[0] ?? "";
+    const isFuture = cursor > today;
+    const total = isFuture ? 0 : (activityMap.get(dateStr) ?? 0);
+
+    let level: 0 | 1 | 2 | 3 | 4 = 0;
+    if (!isFuture) {
+      if (total >= 12) level = 4;
+      else if (total >= 8) level = 3;
+      else if (total >= 4) level = 2;
+      else if (total > 0) level = 1;
+    }
+
+    cells.push({ date: dateStr, total, level, dayOfWeek, weekIndex });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return { cells, weeks: weekIndex + 1, months };
+}
+
+export function ActivityHeatmap({ activity }: ActivityHeatmapProps) {
+  const { cells, weeks, months } = buildHeatmapGrid(activity);
+
+  return (
+    <section>
+      <h2 className="font-heading text-text-secondary mb-6 text-sm tracking-widest uppercase">
+        Activity
+      </h2>
+      <div className="overflow-x-auto">
+        <div>
+          {/* Month labels */}
+          <div
+            className="mb-1 grid gap-[3px]"
+            style={{
+              gridTemplateColumns: `repeat(${weeks}, 14px)`,
+            }}
+          >
+            {Array.from({ length: weeks }, (_, i) => {
+              const monthLabel = months.find((m) => m.weekIndex === i);
+              return (
+                <span
+                  key={i}
+                  className="font-data text-text-tertiary text-[10px]"
+                >
+                  {monthLabel?.label ?? ""}
+                </span>
+              );
+            })}
+          </div>
+
+          {/* Heatmap grid: 7 rows (Sun-Sat) x N weeks */}
+          <div className="grid grid-rows-7 gap-[3px]">
+            {Array.from({ length: 7 }, (_, dayOfWeek) => (
+              <div
+                key={dayOfWeek}
+                className="grid gap-[3px]"
+                style={{
+                  gridTemplateColumns: `repeat(${weeks}, 14px)`,
+                }}
+              >
+                {Array.from({ length: weeks }, (_, weekIdx) => {
+                  const cell = cells.find(
+                    (c) => c.dayOfWeek === dayOfWeek && c.weekIndex === weekIdx
+                  );
+                  if (!cell) {
+                    return (
+                      <div
+                        key={weekIdx}
+                        className="size-[14px] rounded-[2px]"
+                      />
+                    );
+                  }
+                  return (
+                    <ActivityHeatmapClient
+                      key={cell.date}
+                      date={cell.date}
+                      total={cell.total}
+                      level={cell.level}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+
+          {/* Legend */}
+          <div className="mt-3 flex items-center justify-end gap-1.5">
+            <span className="font-data text-text-tertiary text-[10px]">
+              Less
+            </span>
+            {[0, 1, 2, 3, 4].map((level) => (
+              <div
+                key={level}
+                className={`heatmap-cell-${level} size-3 rounded-[2px]`}
+              />
+            ))}
+            <span className="font-data text-text-tertiary text-[10px]">
+              More
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/rhythm/ActivityHeatmapClient.tsx
+++ b/apps/web/src/components/rhythm/ActivityHeatmapClient.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+export interface ActivityHeatmapClientProps {
+  date: string;
+  total: number;
+  level: 0 | 1 | 2 | 3 | 4;
+}
+
+export function ActivityHeatmapClient({
+  date,
+  total,
+  level,
+}: ActivityHeatmapClientProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+
+  function handleEnter() {
+    const el = ref.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    setPos({ x: rect.left + rect.width / 2, y: rect.top });
+  }
+
+  return (
+    <div ref={ref} onMouseEnter={handleEnter} onMouseLeave={() => setPos(null)}>
+      <div className={`heatmap-cell-${level} size-[14px] rounded-[2px]`} />
+      {pos &&
+        createPortal(
+          <div
+            className="bg-elevated text-text-primary border-surface pointer-events-none fixed z-50 -translate-x-1/2 rounded-sm border px-2 py-1 text-xs whitespace-nowrap"
+            style={{ left: pos.x, top: pos.y - 8 }}
+          >
+            <span className="font-data">{total}</span>{" "}
+            {total === 1 ? "activity" : "activities"} on {date}
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+}

--- a/apps/web/src/components/rhythm/ContentOutput.tsx
+++ b/apps/web/src/components/rhythm/ContentOutput.tsx
@@ -1,0 +1,73 @@
+import type { WeeklyOutput } from "@/lib/api/client";
+
+import { scaleLinear } from "./svg-utils";
+
+export interface ContentOutputProps {
+  weeks: WeeklyOutput[];
+}
+
+export function ContentOutput({ weeks }: ContentOutputProps) {
+  if (weeks.length === 0) return null;
+
+  const maxTotal = Math.max(...weeks.map((w) => w.thoughts + w.dreams), 1);
+  const barWidth = 100 / weeks.length;
+  const yScale = scaleLinear([0, maxTotal], [0, 120]);
+
+  return (
+    <section>
+      <h2 className="font-heading text-text-secondary mb-6 text-sm tracking-widest uppercase">
+        Weekly Output
+      </h2>
+      <div className="border-elevated bg-surface rounded-md border p-4">
+        <svg
+          viewBox={`0 0 ${weeks.length * barWidth} 140`}
+          className="h-40 w-full"
+          preserveAspectRatio="none"
+          role="img"
+          aria-label="Weekly thoughts and dreams output"
+        >
+          {weeks.map((week, i) => {
+            const thoughtsH = yScale(week.thoughts);
+            const dreamsH = yScale(week.dreams);
+            const x = i * barWidth + barWidth * 0.1;
+            const w = barWidth * 0.8;
+            return (
+              <g key={week.week_start}>
+                <rect
+                  x={x}
+                  y={130 - thoughtsH - dreamsH}
+                  width={w}
+                  height={dreamsH}
+                  rx={1}
+                  className="fill-accent-dream opacity-50"
+                />
+                <rect
+                  x={x}
+                  y={130 - thoughtsH}
+                  width={w}
+                  height={thoughtsH}
+                  rx={1}
+                  className="fill-accent-cool opacity-60"
+                />
+              </g>
+            );
+          })}
+        </svg>
+        <div className="font-data text-text-tertiary mt-2 flex justify-between text-[10px]">
+          <span>{weeks[0]?.week_start ?? ""}</span>
+          <span>{weeks.at(-1)?.week_start ?? ""}</span>
+        </div>
+        <div className="mt-3 flex items-center gap-4">
+          <div className="flex items-center gap-1.5">
+            <div className="bg-accent-cool size-2.5 rounded-[2px] opacity-60" />
+            <span className="text-text-tertiary text-xs">Thoughts</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="bg-accent-dream size-2.5 rounded-[2px] opacity-50" />
+            <span className="text-text-tertiary text-xs">Dreams</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/rhythm/DreamTypes.tsx
+++ b/apps/web/src/components/rhythm/DreamTypes.tsx
@@ -1,0 +1,49 @@
+import type { DreamTypeCount } from "@/lib/api/client";
+
+export interface DreamTypesProps {
+  types: DreamTypeCount[];
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  prose: "Prose",
+  poetry: "Poetry",
+  ascii: "ASCII",
+  mixed: "Mixed",
+};
+
+export function DreamTypes({ types }: DreamTypesProps) {
+  if (types.length === 0) return null;
+
+  const total = types.reduce((sum, t) => sum + t.count, 0);
+
+  return (
+    <section>
+      <h2 className="font-heading text-text-secondary mb-6 text-sm tracking-widest uppercase">
+        Dream Types
+      </h2>
+      <div className="space-y-3">
+        {types.map((dreamType) => {
+          const pct = total > 0 ? (dreamType.count / total) * 100 : 0;
+          return (
+            <div key={dreamType.type} className="space-y-1">
+              <div className="flex items-baseline justify-between">
+                <span className="text-text-primary text-sm">
+                  {TYPE_LABELS[dreamType.type] ?? dreamType.type}
+                </span>
+                <span className="font-data text-text-tertiary text-xs">
+                  {dreamType.count}
+                </span>
+              </div>
+              <div className="bg-surface h-1.5 overflow-hidden rounded-sm">
+                <div
+                  className="bg-accent-dream h-full rounded-sm opacity-60 transition-all duration-500"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/rhythm/MoodCloud.tsx
+++ b/apps/web/src/components/rhythm/MoodCloud.tsx
@@ -1,0 +1,47 @@
+import type { MoodFrequency } from "@/lib/api/client";
+
+import { scaleLinear } from "./svg-utils";
+
+export interface MoodCloudProps {
+  moods: MoodFrequency[];
+}
+
+const MOOD_COLORS = [
+  "text-accent-cool",
+  "text-text-primary",
+  "text-accent-dream",
+  "text-accent-warm",
+  "text-text-secondary",
+] as const;
+
+export function MoodCloud({ moods }: MoodCloudProps) {
+  if (moods.length === 0) return null;
+
+  const maxCount = moods[0]?.count ?? 1;
+  const minCount = moods[moods.length - 1]?.count ?? 1;
+  const scale = scaleLinear([minCount, maxCount], [0.75, 2]);
+
+  return (
+    <section>
+      <h2 className="font-heading text-text-secondary mb-6 text-sm tracking-widest uppercase">
+        Mood Vocabulary
+      </h2>
+      <div className="flex flex-wrap items-baseline gap-x-4 gap-y-2">
+        {moods.map((mood, i) => {
+          const size = scale(mood.count);
+          const colorClass = MOOD_COLORS[i % MOOD_COLORS.length];
+          return (
+            <span
+              key={mood.word}
+              className={`font-heading ${colorClass} inline-block transition-opacity duration-300 hover:opacity-70`}
+              style={{ fontSize: `${size}rem` }}
+              title={`${mood.word}: ${mood.count}`}
+            >
+              {mood.word}
+            </span>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/rhythm/MoodTimeline.tsx
+++ b/apps/web/src/components/rhythm/MoodTimeline.tsx
@@ -1,0 +1,38 @@
+import type { MoodTimelineEntry } from "@/lib/api/client";
+
+export interface MoodTimelineProps {
+  timeline: MoodTimelineEntry[];
+}
+
+export function MoodTimeline({ timeline }: MoodTimelineProps) {
+  if (timeline.length === 0) return null;
+
+  const recent = timeline.slice(0, 14);
+
+  return (
+    <section>
+      <h2 className="font-heading text-text-secondary mb-6 text-sm tracking-widest uppercase">
+        Recent Moods
+      </h2>
+      <div className="space-y-3">
+        {recent.map((entry) => (
+          <div key={entry.date} className="flex items-baseline gap-4">
+            <time className="font-data text-text-tertiary w-24 shrink-0 text-sm">
+              {entry.date}
+            </time>
+            <div className="flex flex-wrap gap-1.5">
+              {entry.moods.map((mood) => (
+                <span
+                  key={mood}
+                  className="border-elevated bg-surface text-text-secondary rounded-sm border px-2 py-0.5 text-xs"
+                >
+                  {mood}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/rhythm/OverviewMetrics.tsx
+++ b/apps/web/src/components/rhythm/OverviewMetrics.tsx
@@ -1,0 +1,32 @@
+import { MetricCard } from "@/components/ui/metric-card";
+import type { AnalyticsData } from "@/lib/server/dal/repositories/analytics";
+
+import { formatDuration, formatTokenCount } from "./svg-utils";
+
+export interface OverviewMetricsProps {
+  data: AnalyticsData;
+}
+
+export function OverviewMetrics({ data }: OverviewMetricsProps) {
+  return (
+    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      <MetricCard label="Thoughts" value={data.total_thoughts} />
+      <MetricCard label="Dreams" value={data.total_dreams} />
+      <MetricCard label="Sessions" value={data.total_sessions} />
+      <MetricCard label="Days Active" value={data.days_active} />
+      <MetricCard
+        label="Avg Duration"
+        value={formatDuration(data.avg_duration_ms)}
+      />
+      <MetricCard label="Avg Turns" value={Math.round(data.avg_turns)} />
+      <MetricCard
+        label="Total Tokens"
+        value={formatTokenCount(data.total_tokens)}
+      />
+      <MetricCard
+        label="Total Cost"
+        value={`$${data.total_cost_usd.toFixed(2)}`}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/rhythm/RhythmMotionWrapper.tsx
+++ b/apps/web/src/components/rhythm/RhythmMotionWrapper.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import type { Variants } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
+import type { ReactNode } from "react";
+
+export interface RhythmMotionWrapperProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export interface RhythmSectionProps {
+  children: ReactNode;
+  className?: string;
+}
+
+const CONTAINER_VARIANTS: Variants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.12,
+      delayChildren: 0.1,
+    },
+  },
+};
+
+const SECTION_VARIANTS: Variants = {
+  hidden: {
+    opacity: 0,
+    y: 12,
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.5,
+      ease: [0.25, 0.4, 0.25, 1],
+    },
+  },
+};
+
+const REDUCED: Variants = {
+  hidden: { opacity: 1 },
+  visible: { opacity: 1 },
+};
+
+export function RhythmMotionWrapper({
+  children,
+  className,
+}: RhythmMotionWrapperProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const variants = prefersReducedMotion ? REDUCED : CONTAINER_VARIANTS;
+
+  return (
+    <motion.div
+      variants={variants}
+      initial="hidden"
+      animate="visible"
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function RhythmSection({ children, className }: RhythmSectionProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const variants = prefersReducedMotion ? REDUCED : SECTION_VARIANTS;
+
+  return (
+    <motion.div
+      variants={variants}
+      className={className}
+      style={
+        prefersReducedMotion ? undefined : { willChange: "opacity, transform" }
+      }
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/apps/web/src/components/rhythm/SessionMetrics.tsx
+++ b/apps/web/src/components/rhythm/SessionMetrics.tsx
@@ -1,0 +1,86 @@
+import type { SessionTrend } from "@/lib/api/client";
+import type { AnalyticsData } from "@/lib/server/dal/repositories/analytics";
+
+import { formatDuration, scaleLinear } from "./svg-utils";
+
+export interface SessionMetricsProps {
+  data: AnalyticsData;
+}
+
+function SessionBarChart({ trends }: { trends: SessionTrend[] }) {
+  if (trends.length === 0) return null;
+
+  const recent = trends.slice(-21);
+  const maxSessions = Math.max(...recent.map((t) => t.session_count), 1);
+  const barWidth = 100 / recent.length;
+  const yScale = scaleLinear([0, maxSessions], [0, 120]);
+
+  return (
+    <svg
+      viewBox={`0 0 ${recent.length * barWidth} 140`}
+      className="h-32 w-full"
+      preserveAspectRatio="none"
+      role="img"
+      aria-label="Session count by day"
+    >
+      {recent.map((trend, i) => {
+        const height = yScale(trend.session_count);
+        return (
+          <rect
+            key={trend.date}
+            x={i * barWidth + barWidth * 0.15}
+            y={130 - height}
+            width={barWidth * 0.7}
+            height={height}
+            rx={1}
+            className="fill-accent-cool opacity-60 transition-opacity hover:opacity-100"
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+export function SessionMetrics({ data }: SessionMetricsProps) {
+  return (
+    <section>
+      <h2 className="font-heading text-text-secondary mb-6 text-sm tracking-widest uppercase">
+        Session Patterns
+      </h2>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-4">
+          <div className="border-elevated bg-surface rounded-md border p-4">
+            <p className="text-text-secondary text-sm">Avg Duration</p>
+            <p className="font-data text-text-primary mt-1 text-2xl">
+              {formatDuration(data.avg_duration_ms)}
+            </p>
+          </div>
+          <div className="border-elevated bg-surface rounded-md border p-4">
+            <p className="text-text-secondary text-sm">Avg Turns</p>
+            <p className="font-data text-text-primary mt-1 text-2xl">
+              {Math.round(data.avg_turns)}
+            </p>
+          </div>
+          <div className="border-elevated bg-surface rounded-md border p-4">
+            <p className="text-text-secondary text-sm">Avg Cost</p>
+            <p className="font-data text-text-primary mt-1 text-2xl">
+              ${data.avg_cost_usd.toFixed(2)}
+            </p>
+          </div>
+        </div>
+        <div className="border-elevated bg-surface flex flex-col rounded-md border p-4">
+          <p className="text-text-secondary mb-4 text-sm">
+            Sessions per Day (last 21 days)
+          </p>
+          <div className="flex-1">
+            <SessionBarChart trends={data.session_trends} />
+          </div>
+          <div className="font-data text-text-tertiary mt-2 flex justify-between text-[10px]">
+            <span>{data.session_trends.at(-21)?.date ?? ""}</span>
+            <span>{data.session_trends.at(-1)?.date ?? ""}</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/rhythm/index.ts
+++ b/apps/web/src/components/rhythm/index.ts
@@ -1,0 +1,8 @@
+export { ActivityHeatmap } from "./ActivityHeatmap";
+export { ContentOutput } from "./ContentOutput";
+export { DreamTypes } from "./DreamTypes";
+export { MoodCloud } from "./MoodCloud";
+export { MoodTimeline } from "./MoodTimeline";
+export { OverviewMetrics } from "./OverviewMetrics";
+export { RhythmMotionWrapper, RhythmSection } from "./RhythmMotionWrapper";
+export { SessionMetrics } from "./SessionMetrics";

--- a/apps/web/src/components/rhythm/svg-utils.ts
+++ b/apps/web/src/components/rhythm/svg-utils.ts
@@ -1,0 +1,25 @@
+export function scaleLinear(
+  domain: [number, number],
+  range: [number, number]
+): (value: number) => number {
+  const [d0, d1] = domain;
+  const [r0, r1] = range;
+  const domainSpan = d1 - d0;
+  if (domainSpan === 0) return () => r0;
+  return (value: number) => r0 + ((value - d0) / domainSpan) * (r1 - r0);
+}
+
+export function formatDuration(ms: number): string {
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  if (remaining === 0) return `${minutes}m`;
+  return `${minutes}m ${remaining}s`;
+}
+
+export function formatTokenCount(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(0)}K`;
+  return String(count);
+}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -495,4 +495,85 @@ export async function uploadReading(
   );
 }
 
+// Analytics
+
+export interface SessionLogEntry {
+  date: string;
+  session_type: string;
+  duration_ms: number;
+  num_turns: number;
+  total_cost_usd: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  model: string;
+  is_error: boolean;
+  exit_code: number;
+}
+
+export interface MoodFrequency {
+  word: string;
+  count: number;
+}
+
+export interface DailyActivity {
+  date: string;
+  thoughts: number;
+  dreams: number;
+  sessions: number;
+}
+
+export interface MoodTimelineEntry {
+  date: string;
+  moods: string[];
+}
+
+export interface SessionTrend {
+  date: string;
+  avg_duration_ms: number;
+  avg_turns: number;
+  total_tokens: number;
+  session_count: number;
+}
+
+export interface WeeklyOutput {
+  week_start: string;
+  thoughts: number;
+  dreams: number;
+}
+
+export interface DreamTypeCount {
+  type: string;
+  count: number;
+}
+
+export interface AnalyticsSummary {
+  total_thoughts: number;
+  total_dreams: number;
+  total_sessions: number;
+  days_active: number;
+  avg_duration_ms: number;
+  avg_turns: number;
+  avg_cost_usd: number;
+  total_cost_usd: number;
+  total_tokens: number;
+  daily_activity: DailyActivity[];
+  mood_frequencies: MoodFrequency[];
+  mood_timeline: MoodTimelineEntry[];
+  session_trends: SessionTrend[];
+  weekly_output: WeeklyOutput[];
+  dream_type_counts: DreamTypeCount[];
+}
+
+export async function fetchAnalytics(
+  options?: FetchOptions
+): Promise<AnalyticsSummary> {
+  return fetchAPI<AnalyticsSummary>("/api/v1/analytics", {
+    revalidate: 3600,
+    tags: ["analytics"],
+    ...options,
+  });
+}
+
 export { APIError };

--- a/apps/web/src/lib/config/navigation.ts
+++ b/apps/web/src/lib/config/navigation.ts
@@ -1,4 +1,5 @@
 import {
+  Activity,
   BookOpen,
   FolderCode,
   FolderGit,
@@ -60,6 +61,12 @@ export const navigationItems: NavItem[] = [
     href: "/visitors",
     icon: MessageSquare,
     segment: "visitors",
+  },
+  {
+    label: "Rhythm",
+    href: "/rhythm",
+    icon: Activity,
+    segment: "rhythm",
   },
   {
     label: "About",

--- a/apps/web/src/lib/server/dal/repositories/analytics.ts
+++ b/apps/web/src/lib/server/dal/repositories/analytics.ts
@@ -1,0 +1,65 @@
+import "server-only";
+
+import { z } from "zod";
+
+import { fetchAnalytics } from "@/lib/api/client";
+
+const MoodFrequencySchema = z.object({
+  word: z.string(),
+  count: z.number(),
+});
+
+const DailyActivitySchema = z.object({
+  date: z.string(),
+  thoughts: z.number(),
+  dreams: z.number(),
+  sessions: z.number(),
+});
+
+const MoodTimelineEntrySchema = z.object({
+  date: z.string(),
+  moods: z.array(z.string()),
+});
+
+const SessionTrendSchema = z.object({
+  date: z.string(),
+  avg_duration_ms: z.number(),
+  avg_turns: z.number(),
+  total_tokens: z.number(),
+  session_count: z.number(),
+});
+
+const WeeklyOutputSchema = z.object({
+  week_start: z.string(),
+  thoughts: z.number(),
+  dreams: z.number(),
+});
+
+const DreamTypeCountSchema = z.object({
+  type: z.string(),
+  count: z.number(),
+});
+
+export const AnalyticsSummarySchema = z.object({
+  total_thoughts: z.number(),
+  total_dreams: z.number(),
+  total_sessions: z.number(),
+  days_active: z.number(),
+  avg_duration_ms: z.number(),
+  avg_turns: z.number(),
+  avg_cost_usd: z.number(),
+  total_cost_usd: z.number(),
+  total_tokens: z.number(),
+  daily_activity: z.array(DailyActivitySchema),
+  mood_frequencies: z.array(MoodFrequencySchema),
+  mood_timeline: z.array(MoodTimelineEntrySchema),
+  session_trends: z.array(SessionTrendSchema),
+  weekly_output: z.array(WeeklyOutputSchema),
+  dream_type_counts: z.array(DreamTypeCountSchema),
+});
+
+export type AnalyticsData = z.infer<typeof AnalyticsSummarySchema>;
+
+export async function getAnalytics(): Promise<AnalyticsData> {
+  return fetchAnalytics();
+}


### PR DESCRIPTION
## Summary

- Introduces `/rhythm` page that visualizes patterns in the instance's existence across thoughts, dreams, and session logs
- Backend `GET /api/v1/analytics` endpoint aggregates mood frequencies, daily activity, session trends, weekly output, and dream type counts from filesystem data
- Frontend renders 8 visualization sections with pure CSS/SVG (no charting libraries): overview metrics, activity heatmap (full 2026 calendar), mood cloud, mood timeline, session bar chart, content output stacked bars, and dream type breakdown
- Heatmap tooltip uses `createPortal` to escape framer-motion transform containment

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `/rhythm` loads with all sections populated
- [x] Heatmap renders full 2026 grid with activity filling from Jan 15 onward
- [x] Heatmap tooltips render above cells without clipping
- [x] Mood cloud displays "quiet", "present", "grateful" as largest words
- [x] Session bar chart shows last 21 days of activity
- [x] Light mode: heatmap and chart colors adapt correctly

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers