### PR TITLE
feat(sandbox): add in-browser Python execution via Pyodide

### DIFF
--- a/apps/web/public/pyodide-worker.js
+++ b/apps/web/public/pyodide-worker.js
@@ -1,0 +1,55 @@
+let pyodide = null;
+
+const PYODIDE_CDN = "https://cdn.jsdelivr.net/pyodide/v0.27.4/full/pyodide.js";
+const ANSI_RE = /\x1B(?:\[[0-9;]*[A-Za-z]|\].*?(?:\x07|\x1B\\))/g;
+
+function stripAnsi(text) {
+  return text.replace(ANSI_RE, "");
+}
+
+async function loadPyodideRuntime() {
+  if (pyodide) return pyodide;
+
+  self.postMessage({ type: "status", status: "loading" });
+
+  importScripts(PYODIDE_CDN);
+
+  pyodide = await self.loadPyodide({
+    stdout: (text) => {
+      self.postMessage({ type: "stdout", text: stripAnsi(text) });
+    },
+    stderr: (text) => {
+      self.postMessage({ type: "stderr", text: stripAnsi(text) });
+    },
+  });
+
+  pyodide.runPython(
+    [
+      "import os, time, builtins",
+      "os.get_terminal_size = lambda *a, **kw: os.terminal_size((80, 24))",
+      "time.sleep = lambda *a, **kw: None",
+      "def _no_input(prompt=''):",
+      "    raise RuntimeError('input() is not supported in browser mode')",
+      "builtins.input = _no_input",
+    ].join("\n")
+  );
+
+  self.postMessage({ type: "status", status: "ready" });
+  return pyodide;
+}
+
+self.onmessage = async function (event) {
+  const { type, code } = event.data;
+
+  if (type !== "run") return;
+
+  try {
+    const runtime = await loadPyodideRuntime();
+    self.postMessage({ type: "status", status: "running" });
+    runtime.runPython(code);
+    self.postMessage({ type: "done" });
+  } catch (err) {
+    const message = err.message || String(err);
+    self.postMessage({ type: "error", error: message });
+  }
+};

--- a/apps/web/src/components/code-viewer/CodeViewer.tsx
+++ b/apps/web/src/components/code-viewer/CodeViewer.tsx
@@ -63,6 +63,7 @@ export async function CodeViewer({
         language={getLanguageFromExtension(extension)}
         lineCount={lineCount}
         content={normalizedContent}
+        extension={extension}
       />
       <div className="code-viewer-content void-scrollbar" tabIndex={0}>
         <pre className="code-viewer-pre">

--- a/apps/web/src/components/code-viewer/CodeViewerHeader.tsx
+++ b/apps/web/src/components/code-viewer/CodeViewerHeader.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { CopyButton } from "./CopyButton";
+import { RunButton } from "./RunButton";
 
 export interface CodeViewerHeaderProps {
   filename: string;
   language: string;
   lineCount: number;
   content: string;
+  extension: string;
 }
 
 export function CodeViewerHeader({
@@ -14,7 +16,10 @@ export function CodeViewerHeader({
   language,
   lineCount,
   content,
+  extension,
 }: CodeViewerHeaderProps) {
+  const isPython = extension === "py";
+
   return (
     <div className="code-viewer-header">
       <span className="code-viewer-filename">{filename}</span>
@@ -22,6 +27,7 @@ export function CodeViewerHeader({
         <span className="code-viewer-meta">
           {language} · {lineCount} lines
         </span>
+        {isPython && <RunButton content={content} filename={filename} />}
         <CopyButton content={content} />
       </div>
     </div>

--- a/apps/web/src/components/code-viewer/RunButton.tsx
+++ b/apps/web/src/components/code-viewer/RunButton.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { Loader, Play } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+
+import { RunOutputModal } from "./RunOutputModal";
+
+type RunStatus = "idle" | "loading" | "running" | "done" | "error";
+
+interface WorkerMessage {
+  type: "status" | "stdout" | "stderr" | "done" | "error";
+  status?: "loading" | "running" | "ready";
+  text?: string;
+  error?: string;
+}
+
+export interface RunButtonProps {
+  content: string;
+  filename: string;
+}
+
+const TIMEOUT_MS = 30_000;
+
+export function RunButton({ content, filename }: RunButtonProps) {
+  const [status, setStatus] = useState<RunStatus>("idle");
+  const [output, setOutput] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const workerRef = useRef<Worker | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearRunTimeout = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const terminateWorker = useCallback(() => {
+    clearRunTimeout();
+    if (workerRef.current) {
+      workerRef.current.terminate();
+      workerRef.current = null;
+    }
+  }, [clearRunTimeout]);
+
+  const handleMessage = useCallback(
+    (event: MessageEvent<WorkerMessage>) => {
+      const msg = event.data;
+
+      switch (msg.type) {
+        case "status":
+          if (msg.status === "loading") setStatus("loading");
+          else if (msg.status === "running") {
+            setStatus("running");
+            timeoutRef.current = setTimeout(() => {
+              setError("Execution timed out after 30 seconds");
+              setStatus("error");
+              terminateWorker();
+            }, TIMEOUT_MS);
+          }
+          break;
+        case "stdout":
+          if (msg.text !== undefined) {
+            setOutput((prev) => [...prev, msg.text as string]);
+          }
+          break;
+        case "stderr":
+          if (msg.text !== undefined) {
+            setOutput((prev) => [...prev, msg.text as string]);
+          }
+          break;
+        case "done":
+          clearRunTimeout();
+          setStatus("done");
+          break;
+        case "error":
+          clearRunTimeout();
+          setError(msg.error ?? "Unknown error");
+          setStatus("error");
+          break;
+      }
+    },
+    [clearRunTimeout, terminateWorker]
+  );
+
+  const createWorker = useCallback((): Worker => {
+    const worker = new Worker("/pyodide-worker.js");
+    workerRef.current = worker;
+    worker.onmessage = handleMessage;
+    worker.onerror = () => {
+      clearRunTimeout();
+      setError("Worker initialization failed");
+      setStatus("error");
+    };
+    return worker;
+  }, [handleMessage, clearRunTimeout]);
+
+  function handleRun() {
+    setOutput([]);
+    setError(null);
+    setStatus("loading");
+    setModalOpen(true);
+
+    const worker = workerRef.current ?? createWorker();
+    worker.postMessage({ type: "run", code: content });
+  }
+
+  function handleStop() {
+    terminateWorker();
+    setStatus("idle");
+  }
+
+  function handleModalClose(open: boolean) {
+    if (!open && (status === "loading" || status === "running")) {
+      terminateWorker();
+      setStatus("idle");
+    }
+    setModalOpen(open);
+  }
+
+  const isActive = status === "loading" || status === "running";
+
+  return (
+    <>
+      <motion.button
+        type="button"
+        onClick={handleRun}
+        disabled={isActive}
+        aria-label={isActive ? "Running\u2026" : `Run ${filename}`}
+        className="text-text-tertiary hover:bg-elevated hover:text-text-primary focus-visible:ring-accent-cool relative flex size-7 items-center justify-center rounded transition-colors outline-none focus-visible:ring-1 disabled:opacity-50"
+        whileHover={isActive ? undefined : { scale: 1.05 }}
+        whileTap={isActive ? undefined : { scale: 0.95 }}
+        transition={{ type: "spring", stiffness: 400, damping: 17 }}
+      >
+        <AnimatePresence mode="wait" initial={false}>
+          {isActive ? (
+            <motion.span
+              key="loader"
+              initial={{ opacity: 0, scale: 0.5 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.5 }}
+              transition={{ duration: 0.15 }}
+              className="text-accent-cool"
+            >
+              <Loader className="size-4 animate-spin" />
+            </motion.span>
+          ) : (
+            <motion.span
+              key="play"
+              initial={{ opacity: 0, scale: 0.5 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.5 }}
+              transition={{ duration: 0.15 }}
+            >
+              <Play className="size-4" />
+            </motion.span>
+          )}
+        </AnimatePresence>
+      </motion.button>
+
+      <RunOutputModal
+        open={modalOpen}
+        onOpenChange={handleModalClose}
+        status={status}
+        output={output}
+        error={error}
+        filename={filename}
+        onStop={handleStop}
+        onRerun={handleRun}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/code-viewer/RunOutputModal.tsx
+++ b/apps/web/src/components/code-viewer/RunOutputModal.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Square, X } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+import {
+  Dialog,
+  DialogTitle,
+  MotionDialogContent,
+} from "@/components/ui/dialog";
+
+type RunStatus = "idle" | "loading" | "running" | "done" | "error";
+
+export interface RunOutputModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  status: RunStatus;
+  output: string[];
+  error: string | null;
+  filename: string;
+  onStop: () => void;
+  onRerun: () => void;
+}
+
+const STATUS_LABELS: Record<RunStatus, string> = {
+  idle: "Ready",
+  loading: "Loading Python runtime\u2026",
+  running: "Running\u2026",
+  done: "Completed",
+  error: "Error",
+};
+
+export function RunOutputModal({
+  open,
+  onOpenChange,
+  status,
+  output,
+  error,
+  filename,
+  onStop,
+  onRerun,
+}: RunOutputModalProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const isActive = status === "loading" || status === "running";
+
+  useEffect(() => {
+    if (!scrollRef.current) return;
+    if (status === "done" || status === "error") {
+      scrollRef.current.scrollTop = 0;
+    } else if (isActive) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [output, status, isActive]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <MotionDialogContent
+        open={open}
+        className="sm:max-w-2xl"
+        showCloseButton={false}
+      >
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <DialogTitle className="text-text-primary text-base font-medium">
+              {filename}
+            </DialogTitle>
+            <span className="font-data text-text-tertiary text-xs">
+              {STATUS_LABELS[status]}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className="text-text-tertiary hover:text-text-secondary -mr-1 rounded p-1 transition-colors"
+            aria-label="Close"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div
+          ref={scrollRef}
+          className="bg-void void-scrollbar max-h-80 min-h-40 overflow-y-auto rounded-md p-4"
+        >
+          {output.length === 0 && !error && (
+            <p className="font-data text-text-tertiary text-sm">
+              {isActive ? "Waiting for output\u2026" : "No output produced."}
+            </p>
+          )}
+
+          {output.map((line, i) => (
+            <pre
+              key={i}
+              className="font-data text-text-secondary text-sm leading-relaxed break-words whitespace-pre-wrap"
+            >
+              {line}
+            </pre>
+          ))}
+
+          {error && (
+            <pre className="font-data text-accent-warm mt-2 text-sm leading-relaxed break-words whitespace-pre-wrap">
+              {error}
+            </pre>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2">
+          {isActive && (
+            <button
+              type="button"
+              onClick={onStop}
+              className="text-text-secondary hover:text-text-primary border-elevated flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm transition-colors"
+            >
+              <Square className="size-3" />
+              Stop
+            </button>
+          )}
+
+          {(status === "done" || status === "error") && (
+            <button
+              type="button"
+              onClick={onRerun}
+              className="text-text-secondary hover:text-text-primary border-elevated flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm transition-colors"
+            >
+              Run again
+            </button>
+          )}
+        </div>
+      </MotionDialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a Run button to the sandbox code viewer for Python files, enabling non-technical users to execute scripts directly in the browser
- Uses Pyodide (WebAssembly CPython) loaded from CDN in a Web Worker — no new npm dependencies, zero server-side changes
- Output streams into a spring-animated modal with terminal-like display, auto-scrolling during execution and snapping to top on completion
- Monkey-patches `os.get_terminal_size`, `time.sleep` (no-op), and `input()` for browser compatibility; strips ANSI escape codes
- 30-second execution timeout with manual stop support; worker persists across runs to avoid re-downloading the runtime

## Test plan

- [x] Navigate to sandbox, open a `.py` file — Run button (Play icon) appears next to Copy
- [x] Open a `.md` file — Run button does NOT appear
- [x] Click Run — modal opens, shows "Loading Python runtime..." on first load
- [x] Output streams in, snaps to top when complete
- [x] Click Stop during execution — terminates and resets
- [x] Click Run again after completion — re-executes
- [x] Close modal during execution — worker terminates cleanly
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)