### PR TITLE
fix(admin): limit conversations card to 3 most recent entries

### DIFF
--- a/apps/web/src/app/panel-admin/_components/conversations-card.tsx
+++ b/apps/web/src/app/panel-admin/_components/conversations-card.tsx
@@ -51,7 +51,7 @@ export function ConversationsCard({
     setStatus("loading");
     setError(null);
 
-    const result = await fetchConversationsAction();
+    const result = await fetchConversationsAction(3);
 
     if (result.success && result.data) {
       setConversations(result.data.conversations);

--- a/apps/web/src/app/panel-admin/page.tsx
+++ b/apps/web/src/app/panel-admin/page.tsx
@@ -11,7 +11,7 @@ import { WakeClaudeCard } from "./_components/wake-claude-card";
 export default async function AdminPanelPage() {
   const [session, conversationsData] = await Promise.all([
     verifyAdminSession(),
-    fetchConversations().catch(() => ({ conversations: [], total: 0 })),
+    fetchConversations(3).catch(() => ({ conversations: [], total: 0 })),
   ]);
 
   return (


### PR DESCRIPTION
## Summary

Reduces the conversations card fetch limit from 10 to 3. The card only needs to surface the most recent custom session responses — fetching 10 adds unnecessary payload and visual clutter.

## Test Plan

- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [x] Protocol Zero passes

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers