### PR TITLE
fix(web): resolve stale search results and conversations cache

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -515,7 +515,7 @@ export async function fetchConversations(
 ): Promise<ConversationsResponse> {
   return fetchAPI<ConversationsResponse>(
     `/api/v1/admin/conversations?limit=${limit}`,
-    { revalidate: false }
+    { revalidate: 0 }
   );
 }
 

--- a/apps/web/src/lib/hooks/useSearch.ts
+++ b/apps/web/src/lib/hooks/useSearch.ts
@@ -82,7 +82,10 @@ export function useSearch(): UseSearchReturn {
         }
 
         const data = (await response.json()) as SearchResponse;
-        setResults(data.results);
+        const sorted = [...data.results].sort((a, b) =>
+          b.date.localeCompare(a.date)
+        );
+        setResults(sorted);
         setTotal(data.total);
         setActiveIndex(0);
       } catch (error) {


### PR DESCRIPTION
## Summary

Search results were not returning content after ~Feb 14 due to the VPS filesystem watcher silently dropping `FileMovedEvent` events from Claude Code CLI's atomic writes (write to temp file, then rename). The watcher and normalizer on the VPS have been patched to handle move events as creation events.

On the frontend, search results are now sorted by date descending so newest content surfaces first. The admin conversations card was also stuck returning cached data because `revalidate: false` in Next.js means "cache forever" — corrected to `revalidate: 0` (no cache).

## Changes

**Frontend (this PR):**
- `useSearch.ts`: Sort results by date descending after API response
- `client.ts`: Fix conversations fetch cache directive (`false` → `0`)

**VPS (deployed separately):**
- `events/watcher.py`: Handle `FileMovedEvent` with `dest_path` for debouncing
- `events/normalizer.py`: Map `FileMovedEvent` to creation events, extract path from `dest_path`

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] Search returns post-Feb-14 content (verified via direct API test)
- [x] Atomic write test file detected and indexed within 3 seconds
- [x] Admin conversations endpoint returns fresh data on each call