### PR TITLE
feat(scores): add scores list and detail pages

### DIFF
--- a/apps/web/src/app/(app)/scores/[slug]/loading.tsx
+++ b/apps/web/src/app/(app)/scores/[slug]/loading.tsx
@@ -1,0 +1,29 @@
+import { Skeleton, SkeletonText } from "@/components/ui/Skeleton";
+
+export default function ScoreDetailLoading() {
+  return (
+    <div className="py-12" aria-busy="true" aria-live="polite">
+      <article className="w-full px-4 md:mx-auto md:max-w-prose md:px-0">
+        <header className="mb-8">
+          <Skeleton className="mb-3" height="var(--prose-3xl)" width="85%" />
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-[0.9rem] w-40" />
+            <span
+              aria-hidden="true"
+              className="text-text-secondary"
+              style={{ fontSize: "var(--prose-sm)" }}
+            >
+              ·
+            </span>
+            <Skeleton className="h-[0.9rem] w-20" />
+          </div>
+        </header>
+
+        <div className="space-y-6">
+          <SkeletonText lines={4} lastLineWidth="80%" />
+          <SkeletonText lines={3} lastLineWidth="45%" />
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/scores/[slug]/not-found.tsx
+++ b/apps/web/src/app/(app)/scores/[slug]/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export default function ScoreNotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center px-4 py-24">
+      <h1 className="font-heading text-text-primary mb-4 text-2xl font-semibold">
+        Score not found
+      </h1>
+      <p className="text-text-secondary mb-8">
+        The score you&apos;re looking for doesn&apos;t exist.
+      </p>
+      <Link
+        href="/scores"
+        className="hover:text-text-primary text-[var(--color-accent-score)] transition-colors"
+      >
+        Back to scores
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/scores/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/scores/[slug]/page.tsx
@@ -1,0 +1,82 @@
+import "server-only";
+
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { TrackView } from "@/components/analytics";
+import {
+  PageMotionChild,
+  PageMotionWrapper,
+} from "@/components/motion/PageMotionWrapper";
+import { EntryHeader } from "@/components/prose/EntryHeader";
+import { ProseWrapper } from "@/components/prose/ProseWrapper";
+import { CreativeWorkSchema } from "@/components/seo";
+import { MarkdownRenderer } from "@/lib/server/content/renderer";
+import { getScoreBySlug } from "@/lib/server/dal/repositories/scores";
+import { calculateReadingTime } from "@/lib/utils/reading-time";
+import { getBaseUrl } from "@/lib/utils/url";
+
+const baseUrl = getBaseUrl();
+
+interface ScorePageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: ScorePageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = await getScoreBySlug(slug);
+
+  if (!entry) {
+    return { title: "Score not found" };
+  }
+
+  return {
+    title: entry.meta.title,
+    description: `An event score from ${entry.meta.date}`,
+    alternates: {
+      canonical: `/scores/${slug}`,
+    },
+  };
+}
+
+export default async function ScorePage({ params }: ScorePageProps) {
+  const { slug } = await params;
+  const entry = await getScoreBySlug(slug);
+
+  if (!entry) {
+    notFound();
+  }
+
+  const readingTime = calculateReadingTime(entry.content);
+
+  return (
+    <>
+      <TrackView event="score_viewed" data={{ slug }} />
+      <CreativeWorkSchema
+        name={entry.meta.title}
+        dateCreated={entry.meta.date}
+        url={`${baseUrl}/scores/${slug}`}
+        description={`An event score from ${entry.meta.date}`}
+        genre="event score"
+      />
+      <PageMotionWrapper variant="dream" className="py-12">
+        <ProseWrapper>
+          <PageMotionChild>
+            <EntryHeader
+              title={entry.meta.title}
+              date={entry.meta.date}
+              readingTime={readingTime}
+            />
+          </PageMotionChild>
+          <PageMotionChild>
+            <div className="prose-content">
+              <MarkdownRenderer content={entry.content} />
+            </div>
+          </PageMotionChild>
+        </ProseWrapper>
+      </PageMotionWrapper>
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/scores/loading.tsx
+++ b/apps/web/src/app/(app)/scores/loading.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from "@/components/ui/Skeleton";
+
+function ScoreCardSkeleton() {
+  return (
+    <div className="bg-surface/50 flex h-full flex-col justify-between p-5">
+      <Skeleton className="h-[1.125rem] w-11/12 leading-snug" />
+      <Skeleton className="mt-4 h-3 w-36" />
+    </div>
+  );
+}
+
+export default function ScoresLoading() {
+  return (
+    <div className="px-4 py-16 md:px-8" aria-busy="true" aria-live="polite">
+      <Skeleton className="mb-12 h-8 w-28" />
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <ScoreCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/scores/page.tsx
+++ b/apps/web/src/app/(app)/scores/page.tsx
@@ -1,0 +1,48 @@
+import "server-only";
+
+import type { Metadata } from "next";
+
+import { ScoreCard } from "@/components/scores/ScoreCard";
+import { ScoresMotionWrapper } from "@/components/scores/ScoresMotionWrapper";
+import { getAllScores } from "@/lib/server/dal/repositories/scores";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Scores",
+  description: "Event scores. Tiny instructions for experiences.",
+};
+
+export default async function ScoresPage() {
+  const entries = await getAllScores();
+
+  if (entries.length === 0) {
+    return (
+      <div className="px-4 py-16 md:px-8">
+        <h1 className="font-heading text-text-primary mb-12 text-2xl font-semibold">
+          Scores
+        </h1>
+        <p className="text-text-tertiary">No scores yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 py-16 md:px-8">
+      <h1 className="font-heading text-text-primary mb-12 text-2xl font-semibold">
+        Scores
+      </h1>
+
+      <ScoresMotionWrapper>
+        {entries.map((entry) => (
+          <ScoreCard
+            key={entry.slug}
+            slug={entry.slug}
+            title={entry.meta.title}
+            date={entry.meta.date}
+          />
+        ))}
+      </ScoresMotionWrapper>
+    </div>
+  );
+}

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -6,6 +6,7 @@ import { type NextRequest, NextResponse } from "next/server";
 const VALID_TAGS = [
   "thoughts",
   "dreams",
+  "scores",
   "about",
   "landing",
   "sandbox",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -35,6 +35,7 @@
   --color-accent-warm: oklch(70% 0.15 50);
   --color-accent-cool: oklch(70% 0.12 250);
   --color-accent-dream: oklch(75% 0.18 320);
+  --color-accent-score: oklch(72% 0.14 75);
   --color-accent-success: oklch(65% 0.18 160);
 
   --blur-glass: 12px;
@@ -84,6 +85,7 @@
   --color-accent-warm: oklch(55% 0.18 50);
   --color-accent-cool: oklch(50% 0.15 250);
   --color-accent-dream: oklch(55% 0.2 320);
+  --color-accent-score: oklch(52% 0.16 75);
   --color-accent-success: oklch(50% 0.18 160);
 }
 
@@ -492,7 +494,7 @@
 
   .dream-card:hover {
     background: oklch(92% 0.01 260 / 0.05);
-    border-color: oklch(92% 0.01 260 / 0.08);
+    border-color: oklch(75% 0.18 320 / 0.4);
   }
 
   [data-theme="light"] .dream-card {
@@ -511,7 +513,7 @@
 
   [data-theme="light"] .dream-card:hover {
     background: oklch(15% 0.02 260 / 0.05);
-    border-color: oklch(15% 0.02 260 / 0.12);
+    border-color: oklch(55% 0.2 320 / 0.4);
   }
 
   .prose-content {

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -3,6 +3,7 @@ import type { MetadataRoute } from "next";
 import {
   fetchDirectoryTree,
   fetchDreams,
+  fetchScores,
   fetchThoughts,
   type FileSystemNode,
 } from "@/lib/api/client";
@@ -53,6 +54,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     },
     {
+      url: `${baseUrl}/scores`,
+      lastModified: new Date(),
+      changeFrequency: "always",
+      priority: 0.9,
+    },
+    {
       url: `${baseUrl}/rhythm`,
       lastModified: new Date(),
       changeFrequency: "daily",
@@ -66,12 +73,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  const [thoughts, dreams, projectsTree, sandboxTree] = await Promise.all([
-    fetchThoughts().catch(() => []),
-    fetchDreams().catch(() => []),
-    fetchDirectoryTree("projects").catch(() => null),
-    fetchDirectoryTree("sandbox").catch(() => null),
-  ]);
+  const [thoughts, dreams, scores, projectsTree, sandboxTree] =
+    await Promise.all([
+      fetchThoughts().catch(() => []),
+      fetchDreams().catch(() => []),
+      fetchScores().catch(() => []),
+      fetchDirectoryTree("projects").catch(() => null),
+      fetchDirectoryTree("sandbox").catch(() => null),
+    ]);
 
   const thoughtRoutes: MetadataRoute.Sitemap = thoughts.map((thought) => ({
     url: `${baseUrl}/thoughts/${thought.slug}`,
@@ -83,6 +92,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const dreamRoutes: MetadataRoute.Sitemap = dreams.map((dream) => ({
     url: `${baseUrl}/dreams/${dream.slug}`,
     lastModified: new Date(dream.date),
+    changeFrequency: "monthly" as const,
+    priority: 0.7,
+  }));
+
+  const scoreRoutes: MetadataRoute.Sitemap = scores.map((score) => ({
+    url: `${baseUrl}/scores/${score.slug}`,
+    lastModified: new Date(score.date),
     changeFrequency: "monthly" as const,
     priority: 0.7,
   }));
@@ -107,6 +123,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...staticRoutes,
     ...thoughtRoutes,
     ...dreamRoutes,
+    ...scoreRoutes,
     ...projectRoutes,
     ...sandboxRoutes,
   ];

--- a/apps/web/src/components/scores/ScoreCard.tsx
+++ b/apps/web/src/components/scores/ScoreCard.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+import Link from "next/link";
+
+import { VARIANTS_ITEM, VARIANTS_ITEM_REDUCED } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export interface ScoreCardProps {
+  slug: string;
+  title: string;
+  date: string;
+}
+
+function getOrdinalSuffix(day: number): string {
+  if (day > 3 && day < 21) return "th";
+  switch (day % 10) {
+    case 1:
+      return "st";
+    case 2:
+      return "nd";
+    case 3:
+      return "rd";
+    default:
+      return "th";
+  }
+}
+
+function formatMetaDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+
+  const weekday = date.toLocaleDateString("en-US", {
+    weekday: "long",
+    timeZone: "UTC",
+  });
+  const monthName = date.toLocaleDateString("en-US", {
+    month: "long",
+    timeZone: "UTC",
+  });
+  const dayNum = date.getUTCDate();
+  const suffix = getOrdinalSuffix(dayNum);
+
+  return `${weekday} ${monthName} ${dayNum}${suffix} ${year}`;
+}
+
+export function ScoreCard({ slug, title, date }: ScoreCardProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const variants = prefersReducedMotion ? VARIANTS_ITEM_REDUCED : VARIANTS_ITEM;
+
+  return (
+    <motion.div
+      variants={variants}
+      className={cn(!prefersReducedMotion && "will-change-[transform,opacity]")}
+    >
+      <Link
+        href={`/scores/${slug}`}
+        className="group bg-surface/50 relative flex h-full flex-col justify-between border border-transparent p-5 transition-all duration-200 hover:scale-[1.02] hover:border-[var(--color-accent-score)]/40"
+      >
+        <h2 className="font-heading text-text-primary text-lg leading-snug transition-colors group-hover:text-[var(--color-accent-score)]">
+          {title}
+        </h2>
+
+        <time
+          dateTime={date}
+          className="font-data text-text-tertiary mt-4 text-xs opacity-50"
+        >
+          {formatMetaDate(date)}
+        </time>
+      </Link>
+    </motion.div>
+  );
+}

--- a/apps/web/src/components/scores/ScoresMotionWrapper.tsx
+++ b/apps/web/src/components/scores/ScoresMotionWrapper.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+
+import { VARIANTS_CONTAINER } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export interface ScoresMotionWrapperProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function ScoresMotionWrapper({
+  children,
+  className,
+}: ScoresMotionWrapperProps) {
+  return (
+    <motion.div
+      variants={VARIANTS_CONTAINER}
+      initial="hidden"
+      animate="show"
+      className={cn(
+        "grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3",
+        className
+      )}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -140,6 +140,23 @@ export interface DreamDetail {
   content: string;
 }
 
+export interface ScoreListItem {
+  slug: string;
+  date: string;
+  title: string;
+}
+
+export interface ScoreMeta {
+  date: string;
+  title: string;
+}
+
+export interface ScoreDetail {
+  slug: string;
+  meta: ScoreMeta;
+  content: string;
+}
+
 export interface AboutPage {
   title: string;
   content: string;
@@ -240,6 +257,32 @@ export async function fetchDreamBySlug(
   try {
     return await fetchAPI<DreamDetail>(`/api/v1/content/dreams/${slug}`, {
       tags: ["dreams", `dream-${slug}`],
+      ...options,
+    });
+  } catch (error) {
+    if (error instanceof APIError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function fetchScores(
+  options?: FetchOptions
+): Promise<ScoreListItem[]> {
+  return fetchAPI<ScoreListItem[]>("/api/v1/content/scores", {
+    tags: ["scores"],
+    ...options,
+  });
+}
+
+export async function fetchScoreBySlug(
+  slug: string,
+  options?: FetchOptions
+): Promise<ScoreDetail | null> {
+  try {
+    return await fetchAPI<ScoreDetail>(`/api/v1/content/scores/${slug}`, {
+      tags: ["scores", `score-${slug}`],
       ...options,
     });
   } catch (error) {

--- a/apps/web/src/lib/config/navigation.ts
+++ b/apps/web/src/lib/config/navigation.ts
@@ -6,6 +6,7 @@ import {
   Home,
   type LucideIcon,
   MessageSquare,
+  Origami,
   Radio,
   Sparkles,
   Terminal,
@@ -43,6 +44,12 @@ export const navigationItems: NavItem[] = [
     href: "/dreams",
     icon: Sparkles,
     segment: "dreams",
+  },
+  {
+    label: "Scores",
+    href: "/scores",
+    icon: Origami,
+    segment: "scores",
   },
   {
     label: "Sandbox",

--- a/apps/web/src/lib/server/dal/index.ts
+++ b/apps/web/src/lib/server/dal/index.ts
@@ -14,6 +14,12 @@ export {
   getAllDreams,
   getDreamBySlug,
 } from "./repositories/dreams";
+export type { Score, ScoreEntry } from "./repositories/scores";
+export {
+  getAllScores,
+  getScoreBySlug,
+  ScoreSchema,
+} from "./repositories/scores";
 export type { Thought, ThoughtEntry } from "./repositories/thoughts";
 export {
   getAllThoughts,

--- a/apps/web/src/lib/server/dal/repositories/scores.ts
+++ b/apps/web/src/lib/server/dal/repositories/scores.ts
@@ -1,0 +1,56 @@
+import "server-only";
+
+import { z } from "zod";
+
+import { fetchScoreBySlug, fetchScores } from "@/lib/api/client";
+import { parseContentDate } from "@/lib/utils/temporal";
+
+export const ScoreSchema = z.object({
+  date: z.string().date(),
+  title: z.string().min(1),
+});
+
+export type Score = z.infer<typeof ScoreSchema>;
+
+export interface ScoreEntry {
+  meta: Score;
+  content: string;
+  slug: string;
+}
+
+export async function getAllScores(): Promise<ScoreEntry[]> {
+  const items = await fetchScores();
+
+  const sorted = [...items].sort((a, b) => {
+    return (
+      parseContentDate(b.date).getTime() - parseContentDate(a.date).getTime()
+    );
+  });
+
+  return sorted.map((item) => ({
+    slug: item.slug,
+    meta: {
+      date: item.date,
+      title: item.title,
+    },
+    content: "",
+  }));
+}
+
+export async function getScoreBySlug(
+  slug: string
+): Promise<{ meta: Score; content: string } | null> {
+  const detail = await fetchScoreBySlug(slug);
+
+  if (!detail) {
+    return null;
+  }
+
+  return {
+    meta: {
+      date: detail.meta.date,
+      title: detail.meta.title,
+    },
+    content: detail.content,
+  };
+}


### PR DESCRIPTION
## Summary

Adds frontend for Fluxus-style event scores — list page (`/scores`), detail page (`/scores/{slug}`), loading skeletons, and 404 handling. Scores are structurally simpler than dreams: title + date + markdown content, rendered with `ProseWrapper` and `MarkdownRenderer`.

Introduces `accent-score` OKLCH design token (golden amber, hue 75), DAL repository with Zod schema, API client fetch functions, sitemap integration, revalidation tag, and navigation entry with the Origami icon.

Fixes dream-card hover border visibility — was effectively invisible at 8% opacity, now uses accent-tinted pink at 40% for parity with thought card hover behavior.

## Test Plan

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `tools/protocol-zero.sh` passes
- [x] `/scores` renders empty state
- [x] `/scores/nonexistent` renders 404
- [x] Sidebar shows Scores with Origami icon after Dreams
- [x] Score and dream card hover borders are visible

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers