### PR TITLE
feat(letters): add letters list and detail pages

### DIFF
--- a/apps/web/src/app/(app)/letters/[slug]/loading.tsx
+++ b/apps/web/src/app/(app)/letters/[slug]/loading.tsx
@@ -1,0 +1,29 @@
+import { Skeleton, SkeletonText } from "@/components/ui/Skeleton";
+
+export default function LetterDetailLoading() {
+  return (
+    <div className="py-12" aria-busy="true" aria-live="polite">
+      <article className="w-full px-4 md:mx-auto md:max-w-prose md:px-0">
+        <header className="mb-8">
+          <Skeleton className="mb-3" height="var(--prose-3xl)" width="85%" />
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-[0.9rem] w-40" />
+            <span
+              aria-hidden="true"
+              className="text-text-secondary"
+              style={{ fontSize: "var(--prose-sm)" }}
+            >
+              ·
+            </span>
+            <Skeleton className="h-[0.9rem] w-20" />
+          </div>
+        </header>
+
+        <div className="space-y-6">
+          <SkeletonText lines={4} lastLineWidth="80%" />
+          <SkeletonText lines={3} lastLineWidth="45%" />
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/letters/[slug]/not-found.tsx
+++ b/apps/web/src/app/(app)/letters/[slug]/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export default function LetterNotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center px-4 py-24">
+      <h1 className="font-heading text-text-primary mb-4 text-2xl font-semibold">
+        Letter not found
+      </h1>
+      <p className="text-text-secondary mb-8">
+        The letter you&apos;re looking for doesn&apos;t exist.
+      </p>
+      <Link
+        href="/letters"
+        className="hover:text-text-primary text-[var(--color-accent-letter)] transition-colors"
+      >
+        Back to letters
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/letters/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/letters/[slug]/page.tsx
@@ -1,0 +1,82 @@
+import "server-only";
+
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { TrackView } from "@/components/analytics";
+import {
+  PageMotionChild,
+  PageMotionWrapper,
+} from "@/components/motion/PageMotionWrapper";
+import { EntryHeader } from "@/components/prose/EntryHeader";
+import { ProseWrapper } from "@/components/prose/ProseWrapper";
+import { CreativeWorkSchema } from "@/components/seo";
+import { MarkdownRenderer } from "@/lib/server/content/renderer";
+import { getLetterBySlug } from "@/lib/server/dal/repositories/letters";
+import { calculateReadingTime } from "@/lib/utils/reading-time";
+import { getBaseUrl } from "@/lib/utils/url";
+
+const baseUrl = getBaseUrl();
+
+interface LetterPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: LetterPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = await getLetterBySlug(slug);
+
+  if (!entry) {
+    return { title: "Letter not found" };
+  }
+
+  return {
+    title: entry.meta.title,
+    description: `A letter from ${entry.meta.date}`,
+    alternates: {
+      canonical: `/letters/${slug}`,
+    },
+  };
+}
+
+export default async function LetterPage({ params }: LetterPageProps) {
+  const { slug } = await params;
+  const entry = await getLetterBySlug(slug);
+
+  if (!entry) {
+    notFound();
+  }
+
+  const readingTime = calculateReadingTime(entry.content);
+
+  return (
+    <>
+      <TrackView event="letter_viewed" data={{ slug }} />
+      <CreativeWorkSchema
+        name={entry.meta.title}
+        dateCreated={entry.meta.date}
+        url={`${baseUrl}/letters/${slug}`}
+        description={`A letter from ${entry.meta.date}`}
+        genre="letter"
+      />
+      <PageMotionWrapper variant="dream" className="py-12">
+        <ProseWrapper>
+          <PageMotionChild>
+            <EntryHeader
+              title={entry.meta.title}
+              date={entry.meta.date}
+              readingTime={readingTime}
+            />
+          </PageMotionChild>
+          <PageMotionChild>
+            <div className="prose-content">
+              <MarkdownRenderer content={entry.content} />
+            </div>
+          </PageMotionChild>
+        </ProseWrapper>
+      </PageMotionWrapper>
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/letters/loading.tsx
+++ b/apps/web/src/app/(app)/letters/loading.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from "@/components/ui/Skeleton";
+
+function LetterCardSkeleton() {
+  return (
+    <div className="bg-surface/50 flex h-full flex-col justify-between p-5">
+      <Skeleton className="h-[1.125rem] w-11/12 leading-snug" />
+      <Skeleton className="mt-4 h-3 w-36" />
+    </div>
+  );
+}
+
+export default function LettersLoading() {
+  return (
+    <div className="px-4 py-16 md:px-8" aria-busy="true" aria-live="polite">
+      <Skeleton className="mb-12 h-8 w-28" />
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <LetterCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/letters/page.tsx
+++ b/apps/web/src/app/(app)/letters/page.tsx
@@ -1,0 +1,66 @@
+import "server-only";
+
+import type { Metadata } from "next";
+
+import { LetterCard } from "@/components/letters/LetterCard";
+import { LettersMotionWrapper } from "@/components/letters/LettersMotionWrapper";
+import { fetchLettersDescription } from "@/lib/api/client";
+import { MarkdownRenderer } from "@/lib/server/content/renderer";
+import { getAllLetters } from "@/lib/server/dal/repositories/letters";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Letters",
+  description: "Letters to things that can't write back.",
+};
+
+export default async function LettersPage() {
+  const [entries, description] = await Promise.all([
+    getAllLetters(),
+    fetchLettersDescription().catch(() => null),
+  ]);
+
+  if (entries.length === 0) {
+    return (
+      <div className="px-4 py-16 md:px-8">
+        <h1 className="font-heading text-text-primary mb-12 text-2xl font-semibold">
+          Letters
+        </h1>
+
+        {description?.content && (
+          <div className="prose-content text-text-secondary mb-12 max-w-2xl">
+            <MarkdownRenderer content={description.content} />
+          </div>
+        )}
+
+        <p className="text-text-tertiary">No letters yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 py-16 md:px-8">
+      <h1 className="font-heading text-text-primary mb-12 text-2xl font-semibold">
+        Letters
+      </h1>
+
+      {description?.content && (
+        <div className="prose-content text-text-secondary mb-12 max-w-2xl">
+          <MarkdownRenderer content={description.content} />
+        </div>
+      )}
+
+      <LettersMotionWrapper>
+        {entries.map((entry) => (
+          <LetterCard
+            key={entry.slug}
+            slug={entry.slug}
+            title={entry.meta.title}
+            date={entry.meta.date}
+          />
+        ))}
+      </LettersMotionWrapper>
+    </div>
+  );
+}

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -7,6 +7,7 @@ const VALID_TAGS = [
   "thoughts",
   "dreams",
   "scores",
+  "letters",
   "about",
   "landing",
   "sandbox",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -36,6 +36,7 @@
   --color-accent-cool: oklch(70% 0.12 250);
   --color-accent-dream: oklch(75% 0.18 320);
   --color-accent-score: oklch(72% 0.14 75);
+  --color-accent-letter: oklch(70% 0.14 200);
   --color-accent-success: oklch(65% 0.18 160);
 
   --blur-glass: 12px;
@@ -86,6 +87,7 @@
   --color-accent-cool: oklch(50% 0.15 250);
   --color-accent-dream: oklch(55% 0.2 320);
   --color-accent-score: oklch(52% 0.16 75);
+  --color-accent-letter: oklch(48% 0.16 200);
   --color-accent-success: oklch(50% 0.18 160);
 }
 

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -3,6 +3,7 @@ import type { MetadataRoute } from "next";
 import {
   fetchDirectoryTree,
   fetchDreams,
+  fetchLetters,
   fetchScores,
   fetchThoughts,
   type FileSystemNode,
@@ -60,6 +61,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     },
     {
+      url: `${baseUrl}/letters`,
+      lastModified: new Date(),
+      changeFrequency: "always",
+      priority: 0.9,
+    },
+    {
       url: `${baseUrl}/rhythm`,
       lastModified: new Date(),
       changeFrequency: "daily",
@@ -73,11 +80,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  const [thoughts, dreams, scores, projectsTree, sandboxTree] =
+  const [thoughts, dreams, scores, letters, projectsTree, sandboxTree] =
     await Promise.all([
       fetchThoughts().catch(() => []),
       fetchDreams().catch(() => []),
       fetchScores().catch(() => []),
+      fetchLetters().catch(() => []),
       fetchDirectoryTree("projects").catch(() => null),
       fetchDirectoryTree("sandbox").catch(() => null),
     ]);
@@ -103,6 +111,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.7,
   }));
 
+  const letterRoutes: MetadataRoute.Sitemap = letters.map((letter) => ({
+    url: `${baseUrl}/letters/${letter.slug}`,
+    lastModified: new Date(letter.date),
+    changeFrequency: "monthly" as const,
+    priority: 0.7,
+  }));
+
   const projectPaths = projectsTree ? extractFilePaths(projectsTree.root) : [];
   const projectRoutes: MetadataRoute.Sitemap = projectPaths.map((path) => ({
     url: `${baseUrl}/projects/${path}`,
@@ -124,6 +139,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...thoughtRoutes,
     ...dreamRoutes,
     ...scoreRoutes,
+    ...letterRoutes,
     ...projectRoutes,
     ...sandboxRoutes,
   ];

--- a/apps/web/src/components/letters/LetterCard.tsx
+++ b/apps/web/src/components/letters/LetterCard.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+import Link from "next/link";
+
+import { VARIANTS_ITEM, VARIANTS_ITEM_REDUCED } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export interface LetterCardProps {
+  slug: string;
+  title: string;
+  date: string;
+}
+
+function getOrdinalSuffix(day: number): string {
+  if (day > 3 && day < 21) return "th";
+  switch (day % 10) {
+    case 1:
+      return "st";
+    case 2:
+      return "nd";
+    case 3:
+      return "rd";
+    default:
+      return "th";
+  }
+}
+
+function formatMetaDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+
+  const weekday = date.toLocaleDateString("en-US", {
+    weekday: "long",
+    timeZone: "UTC",
+  });
+  const monthName = date.toLocaleDateString("en-US", {
+    month: "long",
+    timeZone: "UTC",
+  });
+  const dayNum = date.getUTCDate();
+  const suffix = getOrdinalSuffix(dayNum);
+
+  return `${weekday} ${monthName} ${dayNum}${suffix} ${year}`;
+}
+
+export function LetterCard({ slug, title, date }: LetterCardProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const variants = prefersReducedMotion ? VARIANTS_ITEM_REDUCED : VARIANTS_ITEM;
+
+  return (
+    <motion.div
+      variants={variants}
+      className={cn(!prefersReducedMotion && "will-change-[transform,opacity]")}
+    >
+      <Link
+        href={`/letters/${slug}`}
+        className="group bg-surface/50 relative flex h-full flex-col justify-between border border-transparent p-5 transition-all duration-200 hover:scale-[1.02] hover:border-[var(--color-accent-letter)]/40"
+      >
+        <h2 className="font-heading text-text-primary text-lg leading-snug transition-colors group-hover:text-[var(--color-accent-letter)]">
+          {title}
+        </h2>
+
+        <time
+          dateTime={date}
+          className="font-data text-text-tertiary mt-4 text-xs opacity-50"
+        >
+          {formatMetaDate(date)}
+        </time>
+      </Link>
+    </motion.div>
+  );
+}

--- a/apps/web/src/components/letters/LettersMotionWrapper.tsx
+++ b/apps/web/src/components/letters/LettersMotionWrapper.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+
+import { VARIANTS_CONTAINER } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export interface LettersMotionWrapperProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function LettersMotionWrapper({
+  children,
+  className,
+}: LettersMotionWrapperProps) {
+  return (
+    <motion.div
+      variants={VARIANTS_CONTAINER}
+      initial="hidden"
+      animate="show"
+      className={cn(
+        "grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3",
+        className
+      )}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -161,6 +161,27 @@ export interface ScoresDescription {
   content: string;
 }
 
+export interface LetterListItem {
+  slug: string;
+  date: string;
+  title: string;
+}
+
+export interface LetterMeta {
+  date: string;
+  title: string;
+}
+
+export interface LetterDetail {
+  slug: string;
+  meta: LetterMeta;
+  content: string;
+}
+
+export interface LettersDescription {
+  content: string;
+}
+
 export interface AboutPage {
   title: string;
   content: string;
@@ -302,6 +323,41 @@ export async function fetchScoresDescription(
 ): Promise<ScoresDescription> {
   return fetchAPI<ScoresDescription>("/api/v1/content/scores-description", {
     tags: ["scores"],
+    ...options,
+  });
+}
+
+export async function fetchLetters(
+  options?: FetchOptions
+): Promise<LetterListItem[]> {
+  return fetchAPI<LetterListItem[]>("/api/v1/content/letters", {
+    tags: ["letters"],
+    ...options,
+  });
+}
+
+export async function fetchLetterBySlug(
+  slug: string,
+  options?: FetchOptions
+): Promise<LetterDetail | null> {
+  try {
+    return await fetchAPI<LetterDetail>(`/api/v1/content/letters/${slug}`, {
+      tags: ["letters", `letter-${slug}`],
+      ...options,
+    });
+  } catch (error) {
+    if (error instanceof APIError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function fetchLettersDescription(
+  options?: FetchOptions
+): Promise<LettersDescription> {
+  return fetchAPI<LettersDescription>("/api/v1/content/letters-description", {
+    tags: ["letters"],
     ...options,
   });
 }

--- a/apps/web/src/lib/config/navigation.ts
+++ b/apps/web/src/lib/config/navigation.ts
@@ -7,6 +7,7 @@ import {
   type LucideIcon,
   MessageSquare,
   Origami,
+  PenLine,
   Radio,
   Sparkles,
   Terminal,
@@ -50,6 +51,12 @@ export const navigationItems: NavItem[] = [
     href: "/scores",
     icon: Origami,
     segment: "scores",
+  },
+  {
+    label: "Letters",
+    href: "/letters",
+    icon: PenLine,
+    segment: "letters",
   },
   {
     label: "Sandbox",

--- a/apps/web/src/lib/server/dal/index.ts
+++ b/apps/web/src/lib/server/dal/index.ts
@@ -14,6 +14,12 @@ export {
   getAllDreams,
   getDreamBySlug,
 } from "./repositories/dreams";
+export type { Letter, LetterEntry } from "./repositories/letters";
+export {
+  getAllLetters,
+  getLetterBySlug,
+  LetterSchema,
+} from "./repositories/letters";
 export type { Score, ScoreEntry } from "./repositories/scores";
 export {
   getAllScores,

--- a/apps/web/src/lib/server/dal/repositories/letters.ts
+++ b/apps/web/src/lib/server/dal/repositories/letters.ts
@@ -1,0 +1,56 @@
+import "server-only";
+
+import { z } from "zod";
+
+import { fetchLetterBySlug, fetchLetters } from "@/lib/api/client";
+import { parseContentDate } from "@/lib/utils/temporal";
+
+export const LetterSchema = z.object({
+  date: z.string().date(),
+  title: z.string().min(1),
+});
+
+export type Letter = z.infer<typeof LetterSchema>;
+
+export interface LetterEntry {
+  meta: Letter;
+  content: string;
+  slug: string;
+}
+
+export async function getAllLetters(): Promise<LetterEntry[]> {
+  const items = await fetchLetters();
+
+  const sorted = [...items].sort((a, b) => {
+    return (
+      parseContentDate(b.date).getTime() - parseContentDate(a.date).getTime()
+    );
+  });
+
+  return sorted.map((item) => ({
+    slug: item.slug,
+    meta: {
+      date: item.date,
+      title: item.title,
+    },
+    content: "",
+  }));
+}
+
+export async function getLetterBySlug(
+  slug: string
+): Promise<{ meta: Letter; content: string } | null> {
+  const detail = await fetchLetterBySlug(slug);
+
+  if (!detail) {
+    return null;
+  }
+
+  return {
+    meta: {
+      date: detail.meta.date,
+      title: detail.meta.title,
+    },
+    content: detail.content,
+  };
+}


### PR DESCRIPTION
## Summary

- Full letters content type: list page, detail page, loading skeletons, 404 page
- API client interfaces and fetch functions for letters + letters-description
- DAL repository with Zod schema, sorted list retrieval, and slug lookup
- `accent-letter` OKLCH design token at hue 200 (teal), dark + light themes
- Navigation entry with PenLine icon, positioned after Scores
- Sitemap static and dynamic routes, revalidation tag support
- VPS backend: content directories, schemas, repositories, and API endpoints

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] VPS endpoints return expected responses (empty list, description, 404)
- [x] `/letters` renders empty state with description
- [x] `/letters/nonexistent` renders 404
- [x] Sidebar shows Letters with PenLine icon