### PR TITLE
fix(titles): narrow preamble validation and strip prefill echo

### DIFF
--- a/apps/web/src/lib/server/services/title-generator.ts
+++ b/apps/web/src/lib/server/services/title-generator.ts
@@ -56,6 +56,7 @@ export async function generateTitle(content: string): Promise<string> {
     const raw = textBlock.text
       .trim()
       .toLowerCase()
+      .replace(/^title:\s*/i, "")
       .replace(/[.,!?;:'"]/g, "");
 
     const firstLine = raw.split("\n")[0].trim().slice(0, 50);
@@ -66,11 +67,12 @@ export async function generateTitle(content: string): Promise<string> {
 
     const PREAMBLE_PATTERNS = [
       /^here (are|is)/,
-      /^(i |my |this |the title|a title|some |let me)/,
+      /^(let me|i would|i suggest|i think)/,
       /^(sure|okay|certainly)/,
-      /suggestion/,
-      /evocative/,
-      /journal/,
+      /\bsuggestion/,
+      /\bevocative\b/,
+      /\bjournal entry\b/,
+      /\btitle for\b/,
     ];
 
     if (PREAMBLE_PATTERNS.some((p) => p.test(firstLine))) {


### PR DESCRIPTION
## Summary

- Overly broad preamble patterns (`this `, `my `, `i `, `the title`) were rejecting valid poetic titles as false positives, causing "untitled memory" fallback
- Narrowed to specific conversational phrases (`let me`, `i would`, `i suggest`) and word-boundary patterns (`\bsuggestion`, `\bjournal entry\b`)
- Strip `title:` prefix from Haiku response to handle prefill echo
- Cleared 3 stale "untitled memory" cache entries on VPS

## Test plan

- [x] `pnpm lint` passes
- [x] Protocol Zero passes
- [ ] Previously untitled thoughts regenerate with valid titles on next page load