### PR TITLE
fix(titles): remove trailing whitespace from assistant prefill

### DIFF
--- a/apps/web/src/lib/server/services/title-generator.ts
+++ b/apps/web/src/lib/server/services/title-generator.ts
@@ -43,7 +43,7 @@ export async function generateTitle(content: string): Promise<string> {
         },
         {
           role: "assistant",
-          content: "title: ",
+          content: "title:",
         },
       ],
     });


### PR DESCRIPTION
## Summary

The Anthropic API rejects assistant content ending with trailing whitespace (`"title: "` vs `"title:"`), causing every title generation call to throw and silently fall back to "untitled memory". One character fix.

## Test plan

- [x] Verified via direct API curl that `"title: "` returns `invalid_request_error`
- [x] Verified `"title:"` succeeds
- [x] Cleared stale "untitled memory" cache entries on VPS