### PR TITLE
chore(titles): upgrade title generation model to claude-haiku-4-5

### DIFF
--- a/apps/web/src/lib/server/services/title-generator.ts
+++ b/apps/web/src/lib/server/services/title-generator.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { getAnthropicClient } from "@/lib/api/anthropic";
 
-const MODEL = "claude-3-haiku-20240307";
+const MODEL = "claude-haiku-4-5-20251001";
 const MAX_TOKENS = 30;
 const FALLBACK_TITLE = "untitled memory";
 

--- a/apps/web/src/lib/server/services/title-registry.ts
+++ b/apps/web/src/lib/server/services/title-registry.ts
@@ -6,7 +6,7 @@ import { fetchTitle, storeTitle } from "@/lib/api/client";
 
 import { generateTitle } from "./title-generator";
 
-const MODEL_ID = "claude-3-haiku-20240307";
+const MODEL_ID = "claude-haiku-4-5-20251001";
 
 function hashContent(content: string): string {
   return createHash("sha256").update(content, "utf8").digest("hex");


### PR DESCRIPTION
## Summary

Replace `claude-3-haiku-20240307` with `claude-haiku-4-5-20251001` for title generation. The legacy model intermittently fails to follow the system prompt, producing preamble-laden responses or triggering silent errors that cascade to "untitled memory" fallbacks.

## Test plan

- [x] Build succeeds (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] Verify title generation works after deploy by revalidating thoughts