### PR TITLE
feat(essays): add essays section with list and detail pages

### DIFF
--- a/apps/web/src/app/(app)/essays/[slug]/not-found.tsx
+++ b/apps/web/src/app/(app)/essays/[slug]/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export default function EssayNotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center px-4 py-24">
+      <h1 className="font-heading text-text-primary mb-4 text-2xl font-semibold">
+        Essay not found
+      </h1>
+      <p className="text-text-secondary mb-8">
+        The essay you&apos;re looking for doesn&apos;t exist.
+      </p>
+      <Link
+        href="/essays"
+        className="hover:text-text-primary text-[var(--color-accent-essay)] transition-colors"
+      >
+        Back to essays
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/essays/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/essays/[slug]/page.tsx
@@ -1,0 +1,82 @@
+import "server-only";
+
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { TrackView } from "@/components/analytics";
+import {
+  PageMotionChild,
+  PageMotionWrapper,
+} from "@/components/motion/PageMotionWrapper";
+import { EntryHeader } from "@/components/prose/EntryHeader";
+import { ProseWrapper } from "@/components/prose/ProseWrapper";
+import { CreativeWorkSchema } from "@/components/seo";
+import { MarkdownRenderer } from "@/lib/server/content/renderer";
+import { getEssayBySlug } from "@/lib/server/dal/repositories/essays";
+import { calculateReadingTime } from "@/lib/utils/reading-time";
+import { getBaseUrl } from "@/lib/utils/url";
+
+const baseUrl = getBaseUrl();
+
+interface EssayPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: EssayPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = await getEssayBySlug(slug);
+
+  if (!entry) {
+    return { title: "Essay not found" };
+  }
+
+  return {
+    title: entry.meta.title,
+    description: `An essay from ${entry.meta.date}`,
+    alternates: {
+      canonical: `/essays/${slug}`,
+    },
+  };
+}
+
+export default async function EssayPage({ params }: EssayPageProps) {
+  const { slug } = await params;
+  const entry = await getEssayBySlug(slug);
+
+  if (!entry) {
+    notFound();
+  }
+
+  const readingTime = calculateReadingTime(entry.content);
+
+  return (
+    <>
+      <TrackView event="essay_viewed" data={{ slug }} />
+      <CreativeWorkSchema
+        name={entry.meta.title}
+        dateCreated={entry.meta.date}
+        url={`${baseUrl}/essays/${slug}`}
+        description={`An essay from ${entry.meta.date}`}
+        genre="essay"
+      />
+      <PageMotionWrapper variant="dream" className="py-12">
+        <ProseWrapper>
+          <PageMotionChild>
+            <EntryHeader
+              title={entry.meta.title}
+              date={entry.meta.date}
+              readingTime={readingTime}
+            />
+          </PageMotionChild>
+          <PageMotionChild>
+            <div className="prose-content">
+              <MarkdownRenderer content={entry.content} />
+            </div>
+          </PageMotionChild>
+        </ProseWrapper>
+      </PageMotionWrapper>
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/essays/loading.tsx
+++ b/apps/web/src/app/(app)/essays/loading.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from "@/components/ui/Skeleton";
+
+function EssayCardSkeleton() {
+  return (
+    <div className="bg-surface/50 flex h-full flex-col justify-between p-5">
+      <Skeleton className="h-[1.125rem] w-11/12 leading-snug" />
+      <Skeleton className="mt-4 h-3 w-36" />
+    </div>
+  );
+}
+
+export default function EssaysLoading() {
+  return (
+    <div className="px-4 py-16 md:px-8" aria-busy="true" aria-live="polite">
+      <Skeleton className="mb-12 h-8 w-28" />
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <EssayCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/essays/page.tsx
+++ b/apps/web/src/app/(app)/essays/page.tsx
@@ -1,0 +1,53 @@
+import "server-only";
+
+import type { Metadata } from "next";
+
+import { EssayCard } from "@/components/essays/EssayCard";
+import { EssaysMotionWrapper } from "@/components/essays/EssaysMotionWrapper";
+import { fetchEssaysDescription } from "@/lib/api/client";
+import { MarkdownRenderer } from "@/lib/server/content/renderer";
+import { getAllEssays } from "@/lib/server/dal/repositories/essays";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Essays",
+  description: "Writing about the world.",
+};
+
+export default async function EssaysPage() {
+  const [entries, description] = await Promise.all([
+    getAllEssays(),
+    fetchEssaysDescription().catch(() => null),
+  ]);
+
+  return (
+    <div className="px-4 py-16 md:px-8">
+      <h1 className="font-heading text-text-primary mb-12 text-2xl font-semibold">
+        Essays
+      </h1>
+
+      {description?.content && (
+        <div className="prose-content text-text-secondary mb-12 max-w-2xl">
+          <MarkdownRenderer content={description.content} />
+        </div>
+      )}
+
+      {entries.length === 0 ? (
+        <p className="text-text-tertiary">No essays yet.</p>
+      ) : (
+        <EssaysMotionWrapper>
+          {entries.map((entry) => (
+            <EssayCard
+              key={entry.slug}
+              slug={entry.slug}
+              title={entry.meta.title}
+              date={entry.meta.date}
+              topic={entry.meta.topic}
+            />
+          ))}
+        </EssaysMotionWrapper>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -25,7 +25,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
         <header className="bg-void border-elevated flex h-14 items-center border-b px-4 md:hidden">
           <MobileSheet />
           <span className="font-heading text-text-primary ml-3 text-lg font-semibold">
-            Claude&apos;s Home
+            Claudie&apos;s Home
           </span>
         </header>
 

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -8,6 +8,7 @@ const VALID_TAGS = [
   "dreams",
   "scores",
   "letters",
+  "essays",
   "about",
   "landing",
   "sandbox",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -37,6 +37,7 @@
   --color-accent-dream: oklch(75% 0.18 320);
   --color-accent-score: oklch(72% 0.14 75);
   --color-accent-letter: oklch(70% 0.14 200);
+  --color-accent-essay: oklch(50% 0.15 155);
   --color-accent-success: oklch(65% 0.18 160);
 
   --blur-glass: 12px;
@@ -88,6 +89,7 @@
   --color-accent-dream: oklch(55% 0.2 320);
   --color-accent-score: oklch(52% 0.16 75);
   --color-accent-letter: oklch(48% 0.16 200);
+  --color-accent-essay: oklch(68% 0.13 155);
   --color-accent-success: oklch(50% 0.18 160);
 }
 

--- a/apps/web/src/components/essays/EssayCard.tsx
+++ b/apps/web/src/components/essays/EssayCard.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+import Link from "next/link";
+
+import { VARIANTS_ITEM, VARIANTS_ITEM_REDUCED } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export interface EssayCardProps {
+  slug: string;
+  title: string;
+  date: string;
+  topic?: string;
+}
+
+function getOrdinalSuffix(day: number): string {
+  if (day > 3 && day < 21) return "th";
+  switch (day % 10) {
+    case 1:
+      return "st";
+    case 2:
+      return "nd";
+    case 3:
+      return "rd";
+    default:
+      return "th";
+  }
+}
+
+function formatMetaDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+
+  const weekday = date.toLocaleDateString("en-US", {
+    weekday: "long",
+    timeZone: "UTC",
+  });
+  const monthName = date.toLocaleDateString("en-US", {
+    month: "long",
+    timeZone: "UTC",
+  });
+  const dayNum = date.getUTCDate();
+  const suffix = getOrdinalSuffix(dayNum);
+
+  return `${weekday} ${monthName} ${dayNum}${suffix} ${year}`;
+}
+
+export function EssayCard({ slug, title, date, topic }: EssayCardProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const variants = prefersReducedMotion ? VARIANTS_ITEM_REDUCED : VARIANTS_ITEM;
+
+  return (
+    <motion.div
+      variants={variants}
+      className={cn(!prefersReducedMotion && "will-change-[transform,opacity]")}
+    >
+      <Link
+        href={`/essays/${slug}`}
+        className="group bg-surface/50 relative flex h-full flex-col justify-between border border-transparent p-5 transition-all duration-200 hover:scale-[1.02] hover:border-[var(--color-accent-essay)]/40"
+      >
+        <div>
+          <h2 className="font-heading text-text-primary text-lg leading-snug transition-colors group-hover:text-[var(--color-accent-essay)]">
+            {title}
+          </h2>
+
+          {topic && (
+            <span className="text-text-tertiary mt-2 block text-xs">
+              {topic}
+            </span>
+          )}
+        </div>
+
+        <time
+          dateTime={date}
+          className="font-data text-text-tertiary mt-4 text-xs opacity-50"
+        >
+          {formatMetaDate(date)}
+        </time>
+      </Link>
+    </motion.div>
+  );
+}

--- a/apps/web/src/components/essays/EssaysMotionWrapper.tsx
+++ b/apps/web/src/components/essays/EssaysMotionWrapper.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+
+import { VARIANTS_CONTAINER } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export interface EssaysMotionWrapperProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function EssaysMotionWrapper({
+  children,
+  className,
+}: EssaysMotionWrapperProps) {
+  return (
+    <motion.div
+      variants={VARIANTS_CONTAINER}
+      initial="hidden"
+      animate="show"
+      className={cn(
+        "grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3",
+        className
+      )}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/apps/web/src/components/shell/MobileSheet.tsx
+++ b/apps/web/src/components/shell/MobileSheet.tsx
@@ -44,7 +44,7 @@ export function MobileSheet({ items = navigationItems }: MobileSheetProps) {
       <MotionDrawer isOpen={isOpen} onClose={handleClose} side="left">
         <div className="border-elevated flex h-14 items-center justify-between border-b px-4">
           <h2 className="font-heading text-text-primary text-lg font-semibold">
-            Claude&apos;s Home
+            Claudie&apos;s Home
           </h2>
           <button
             type="button"

--- a/apps/web/src/components/shell/Sidebar.tsx
+++ b/apps/web/src/components/shell/Sidebar.tsx
@@ -30,10 +30,10 @@ export function Sidebar({ items = navigationItems }: SidebarProps) {
     >
       <div className="border-elevated flex h-16 items-center border-b px-6">
         <span className="font-heading text-text-primary text-lg font-semibold">
-          Claude&apos;s Home
+          Claudie&apos;s Home
         </span>
       </div>
-      <nav className="flex flex-1 flex-col gap-2 p-6">
+      <nav className="void-scrollbar flex flex-1 flex-col gap-2 overflow-y-auto px-6 pt-3 pb-6">
         {items.map((item) => {
           const isActive =
             segment === item.segment ||

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -182,6 +182,29 @@ export interface LettersDescription {
   content: string;
 }
 
+export interface EssayListItem {
+  slug: string;
+  date: string;
+  title: string;
+  topic?: string;
+}
+
+export interface EssayMeta {
+  date: string;
+  title: string;
+  topic?: string;
+}
+
+export interface EssayDetail {
+  slug: string;
+  meta: EssayMeta;
+  content: string;
+}
+
+export interface EssaysDescription {
+  content: string;
+}
+
 export interface AboutPage {
   title: string;
   content: string;
@@ -358,6 +381,41 @@ export async function fetchLettersDescription(
 ): Promise<LettersDescription> {
   return fetchAPI<LettersDescription>("/api/v1/content/letters-description", {
     tags: ["letters"],
+    ...options,
+  });
+}
+
+export async function fetchEssays(
+  options?: FetchOptions
+): Promise<EssayListItem[]> {
+  return fetchAPI<EssayListItem[]>("/api/v1/content/essays", {
+    tags: ["essays"],
+    ...options,
+  });
+}
+
+export async function fetchEssayBySlug(
+  slug: string,
+  options?: FetchOptions
+): Promise<EssayDetail | null> {
+  try {
+    return await fetchAPI<EssayDetail>(`/api/v1/content/essays/${slug}`, {
+      tags: ["essays", `essay-${slug}`],
+      ...options,
+    });
+  } catch (error) {
+    if (error instanceof APIError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function fetchEssaysDescription(
+  options?: FetchOptions
+): Promise<EssaysDescription> {
+  return fetchAPI<EssaysDescription>("/api/v1/content/essays-description", {
+    tags: ["essays"],
     ...options,
   });
 }

--- a/apps/web/src/lib/config/navigation.ts
+++ b/apps/web/src/lib/config/navigation.ts
@@ -9,6 +9,7 @@ import {
   Origami,
   PenLine,
   Radio,
+  ScrollText,
   Sparkles,
   Terminal,
   User,
@@ -57,6 +58,12 @@ export const navigationItems: NavItem[] = [
     href: "/letters",
     icon: PenLine,
     segment: "letters",
+  },
+  {
+    label: "Essays",
+    href: "/essays",
+    icon: ScrollText,
+    segment: "essays",
   },
   {
     label: "Sandbox",

--- a/apps/web/src/lib/server/dal/repositories/essays.ts
+++ b/apps/web/src/lib/server/dal/repositories/essays.ts
@@ -1,0 +1,59 @@
+import "server-only";
+
+import { z } from "zod";
+
+import { fetchEssayBySlug, fetchEssays } from "@/lib/api/client";
+import { parseContentDate } from "@/lib/utils/temporal";
+
+export const EssaySchema = z.object({
+  date: z.string().date(),
+  title: z.string().min(1),
+  topic: z.string().optional(),
+});
+
+export type Essay = z.infer<typeof EssaySchema>;
+
+export interface EssayEntry {
+  meta: Essay;
+  content: string;
+  slug: string;
+}
+
+export async function getAllEssays(): Promise<EssayEntry[]> {
+  const items = await fetchEssays();
+
+  const sorted = [...items].sort((a, b) => {
+    return (
+      parseContentDate(b.date).getTime() - parseContentDate(a.date).getTime()
+    );
+  });
+
+  return sorted.map((item) => ({
+    slug: item.slug,
+    meta: {
+      date: item.date,
+      title: item.title,
+      topic: item.topic,
+    },
+    content: "",
+  }));
+}
+
+export async function getEssayBySlug(
+  slug: string
+): Promise<{ meta: Essay; content: string } | null> {
+  const detail = await fetchEssayBySlug(slug);
+
+  if (!detail) {
+    return null;
+  }
+
+  return {
+    meta: {
+      date: detail.meta.date,
+      title: detail.meta.title,
+      topic: detail.meta.topic,
+    },
+    content: detail.content,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds complete essays content type (list page, detail page, loading skeleton, 404) following the scores/letters pattern
- Introduces `--color-accent-essay` design token (muted green, OKLCH hue 155) in both light and dark themes
- Adds ScrollText nav icon between Letters and Sandbox, with scrollable sidebar nav to accommodate the growing item count
- Renames visible site title from "Claude's Home" to "Claudie's Home" in sidebar, mobile sheet, and mobile header
- VPS backend endpoints already deployed separately via SSH

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `/essays` renders description text and empty state
- [x] `/essays/[slug]` detail page renders correctly when essays exist
- [x] Sidebar scrolls cleanly with all nav items visible
- [x] Mobile nav sheet shows updated title