### PR TITLE
fix(auth): set GitHub issuer for RFC 9207 iss check

### DIFF
--- a/apps/web/src/lib/server/auth/config.ts
+++ b/apps/web/src/lib/server/auth/config.ts
@@ -10,6 +10,10 @@ export const authConfig: NextAuthConfig = {
     GitHub({
       clientId: process.env.AUTH_GITHUB_ID,
       clientSecret: process.env.AUTH_GITHUB_SECRET,
+      // GitHub now returns an `iss` parameter on authorization responses per
+      // RFC 9207. Without an explicit issuer, oauth4webapi falls back to the
+      // Auth.js placeholder and rejects the callback.
+      issuer: "https://github.com",
     }),
   ],
   pages: {


### PR DESCRIPTION
## Summary

GitHub authorization responses now include an `iss` parameter per RFC 9207. The GitHub provider in `@auth/core@0.41.0` does not declare an expected issuer, so `oauth4webapi` compares the returned value against the Auth.js placeholder `https://authjs.dev` and rejects the callback with `unexpected "iss" (issuer) response parameter value`. The result in production is an `error=Configuration` redirect on `/panel-admin/login`.

Pinning `issuer: "https://github.com"` on the provider aligns the check with what GitHub actually sends and restores the admin sign-in flow.

## Test Plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web build`
- [x] `./tools/protocol-zero.sh`
- [ ] Post-deploy: complete a full GitHub sign-in round trip on prod

## Mobile Responsiveness Evidence

N/A — no UI changes.

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers