### PR TITLE
feat(landing): redesign hero with asymmetric split and ambient panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ next-env.d.ts
 # Claude
 .claude/*
 !.claude/skills/
+
+# Playwright MCP artifacts
+.playwright-mcp/

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -1,17 +1,16 @@
 import "server-only";
 
-import { ArrowRight } from "lucide-react";
 import type { Metadata } from "next";
-import Link from "next/link";
 
+import { HeroSplit } from "@/components/landing/HeroSplit";
 import { RecentActivity } from "@/components/landing/RecentActivity";
 import { computeStreak } from "@/components/rhythm/svg-utils";
 import { ProfilePageSchema, WebSiteSchema } from "@/components/seo";
-import { LocationHealth } from "@/components/shell/LocationHealth";
 import {
   fetchAnalytics,
   fetchDreams,
   fetchLandingPage,
+  fetchLandingSummary,
   fetchThoughts,
 } from "@/lib/api/client";
 import { MarkdownRenderer } from "@/lib/server/content/renderer";
@@ -28,12 +27,14 @@ export const metadata: Metadata = {
 };
 
 export default async function HomePage() {
-  const [landing, analytics, thoughts, dreams] = await Promise.all([
-    fetchLandingPage(),
-    fetchAnalytics(),
-    fetchThoughts(),
-    fetchDreams(),
-  ]);
+  const [landing, analytics, thoughts, dreams, landingSummary] =
+    await Promise.all([
+      fetchLandingPage(),
+      fetchAnalytics(),
+      fetchThoughts(),
+      fetchDreams(),
+      fetchLandingSummary(),
+    ]);
   const { greeting } = getHelsinkiTimeContext();
   const streak = computeStreak(analytics.daily_activity);
   const latestThought = thoughts[0] ?? null;
@@ -51,45 +52,27 @@ export default async function HomePage() {
         url={baseUrl}
         description="A contemplative digital space for thoughts, dreams, and experiments."
       />
-      <div className="void-breathing flex min-h-[calc(100dvh-3.5rem-2rem)] flex-col items-center justify-center py-12 md:min-h-[calc(100dvh-2rem)]">
-        <div className="w-full max-w-[65ch] px-6">
-          <header className="mb-12 text-center">
-            <div className="animate-resolve mb-8">
-              <LocationHealth />
-            </div>
-            <p className="animate-resolve resolve-delay-1 font-data text-text-tertiary mb-6 text-sm tracking-[0.15em] uppercase">
-              {greeting}
-            </p>
-            <h1
-              id="landing-identity"
-              className="voice-breathing font-heading text-text-primary mb-4 font-medium"
-              style={{
-                fontSize: "clamp(2.5rem, 5vw, 4rem)",
-                letterSpacing: "-0.03em",
-              }}
-            >
-              Claudie&apos;s Home
-            </h1>
-            <p className="animate-resolve resolve-delay-2 font-data text-text-secondary text-base md:text-lg">
-              {landing.subheadline}
-            </p>
-          </header>
-          <RecentActivity
+      <div className="void-breathing flex min-h-[calc(100dvh-3.5rem-2rem)] flex-col justify-center py-8 md:min-h-[calc(100dvh-2rem)] md:py-16">
+        <div className="mx-auto w-full max-w-6xl px-6 md:px-10 lg:px-12">
+          <HeroSplit
+            greeting={greeting}
+            subheadline={landing.subheadline}
+            dailyActivity={analytics.daily_activity}
             streak={streak}
             latestThought={latestThought}
             latestDream={latestDream}
+            landingSummary={landingSummary}
           />
-          <div className="animate-resolve resolve-delay-5 prose-landing">
-            <MarkdownRenderer content={landing.content} />
-          </div>
-          <div className="animate-resolve resolve-delay-6 mt-16 text-center">
-            <Link
-              href="/thoughts"
-              className="border-text-tertiary/20 text-text-secondary hover:border-accent-cool hover:text-text-primary focus-visible:border-accent-cool focus-visible:text-text-primary font-data inline-flex min-h-11 items-center gap-2 rounded-md border px-5 py-2 text-sm tracking-[0.05em] transition-colors duration-300 focus:outline-none"
-            >
-              enter
-              <ArrowRight size={16} aria-hidden="true" />
-            </Link>
+          <div id="landing-continue" className="mt-20 md:mt-28">
+            <div className="mx-auto max-w-[65ch]">
+              <RecentActivity
+                latestThought={latestThought}
+                latestDream={latestDream}
+              />
+              <div className="animate-resolve resolve-delay-6 prose-landing">
+                <MarkdownRenderer content={landing.content} />
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/components/landing/AmbientPanel.tsx
+++ b/apps/web/src/components/landing/AmbientPanel.tsx
@@ -1,0 +1,48 @@
+import { LandingSummaryNote } from "@/components/landing/LandingSummaryNote";
+import { LatestSignal } from "@/components/landing/LatestSignal";
+import { RhythmSparkline } from "@/components/landing/RhythmSparkline";
+import { LocationHealth } from "@/components/shell/LocationHealth";
+import type {
+  DailyActivity,
+  DreamListItem,
+  LandingSummary,
+  ThoughtListItem,
+} from "@/lib/api/client";
+
+interface AmbientPanelProps {
+  dailyActivity: DailyActivity[];
+  streak: number;
+  latestThought: ThoughtListItem | null;
+  latestDream: DreamListItem | null;
+  landingSummary: LandingSummary | null;
+}
+
+export function AmbientPanel({
+  dailyActivity,
+  streak,
+  latestThought,
+  latestDream,
+  landingSummary,
+}: AmbientPanelProps) {
+  return (
+    <aside
+      aria-label="Ambient signals"
+      className="border-text-tertiary/10 flex flex-col gap-8 md:border-l md:pl-8 lg:pl-12"
+    >
+      <div className="animate-resolve resolve-delay-2">
+        <LocationHealth align="start" />
+      </div>
+      <div className="animate-resolve resolve-delay-3">
+        <LatestSignal latestThought={latestThought} latestDream={latestDream} />
+      </div>
+      <div className="animate-resolve resolve-delay-4">
+        <RhythmSparkline dailyActivity={dailyActivity} streak={streak} />
+      </div>
+      {landingSummary ? (
+        <div className="animate-resolve resolve-delay-5">
+          <LandingSummaryNote summary={landingSummary} />
+        </div>
+      ) : null}
+    </aside>
+  );
+}

--- a/apps/web/src/components/landing/HeroSplit.tsx
+++ b/apps/web/src/components/landing/HeroSplit.tsx
@@ -1,0 +1,68 @@
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+import { AmbientPanel } from "@/components/landing/AmbientPanel";
+import type {
+  DailyActivity,
+  DreamListItem,
+  LandingSummary,
+  ThoughtListItem,
+} from "@/lib/api/client";
+
+interface HeroSplitProps {
+  greeting: string;
+  subheadline: string;
+  dailyActivity: DailyActivity[];
+  streak: number;
+  latestThought: ThoughtListItem | null;
+  latestDream: DreamListItem | null;
+  landingSummary: LandingSummary | null;
+}
+
+export function HeroSplit({
+  greeting,
+  subheadline,
+  dailyActivity,
+  streak,
+  latestThought,
+  latestDream,
+  landingSummary,
+}: HeroSplitProps) {
+  return (
+    <section className="grid grid-cols-1 items-center gap-12 md:grid-cols-[1.3fr_1fr] md:gap-12 lg:gap-20">
+      <div className="max-w-[38ch]">
+        <p className="animate-resolve resolve-delay-1 font-data text-text-tertiary mb-6 text-sm tracking-[0.18em] uppercase">
+          {greeting}
+        </p>
+        <h1
+          id="landing-identity"
+          className="voice-breathing font-heading text-text-primary mb-5 font-medium"
+          style={{
+            fontSize: "clamp(2.5rem, 5vw, 4rem)",
+            letterSpacing: "-0.03em",
+            lineHeight: "1",
+          }}
+        >
+          Claudie&apos;s Home
+        </h1>
+        <p className="animate-resolve resolve-delay-2 font-data text-text-secondary mb-10 max-w-[48ch] text-base md:text-lg">
+          {subheadline}
+        </p>
+        <Link
+          href="/thoughts"
+          className="animate-resolve resolve-delay-3 border-text-tertiary/20 text-text-secondary hover:border-accent-cool hover:text-text-primary focus-visible:border-accent-cool focus-visible:text-text-primary font-data inline-flex min-h-11 items-center gap-2 rounded-md border px-5 py-2 text-sm tracking-[0.05em] transition-colors duration-300 focus:outline-none"
+        >
+          enter
+          <ArrowRight size={16} aria-hidden="true" />
+        </Link>
+      </div>
+      <AmbientPanel
+        dailyActivity={dailyActivity}
+        streak={streak}
+        latestThought={latestThought}
+        latestDream={latestDream}
+        landingSummary={landingSummary}
+      />
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/LandingSummaryNote.tsx
+++ b/apps/web/src/components/landing/LandingSummaryNote.tsx
@@ -1,0 +1,23 @@
+import type { LandingSummary } from "@/lib/api/client";
+
+interface LandingSummaryNoteProps {
+  summary: LandingSummary | null;
+}
+
+export function LandingSummaryNote({ summary }: LandingSummaryNoteProps) {
+  const trimmed = summary?.content.trim();
+  if (!trimmed) return null;
+
+  const paragraphs = trimmed
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  return (
+    <blockquote className="font-prose text-text-secondary space-y-3 text-sm leading-relaxed italic">
+      {paragraphs.map((paragraph, i) => (
+        <p key={i}>{paragraph}</p>
+      ))}
+    </blockquote>
+  );
+}

--- a/apps/web/src/components/landing/LatestSignal.tsx
+++ b/apps/web/src/components/landing/LatestSignal.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+
+import type { DreamListItem, ThoughtListItem } from "@/lib/api/client";
+import { formatContentDate } from "@/lib/utils/temporal";
+
+interface LatestSignalProps {
+  latestThought: ThoughtListItem | null;
+  latestDream: DreamListItem | null;
+}
+
+type SignalKind = "thought" | "dream";
+
+interface Signal {
+  kind: SignalKind;
+  href: string;
+  title: string;
+  date: string;
+}
+
+function pickLatest(
+  latestThought: ThoughtListItem | null,
+  latestDream: DreamListItem | null
+): Signal | null {
+  if (!latestThought && !latestDream) return null;
+  if (!latestDream) {
+    return {
+      kind: "thought",
+      href: `/thoughts/${latestThought!.slug}`,
+      title: latestThought!.title,
+      date: latestThought!.date,
+    };
+  }
+  if (!latestThought) {
+    return {
+      kind: "dream",
+      href: `/dreams/${latestDream.slug}`,
+      title: latestDream.title,
+      date: latestDream.date,
+    };
+  }
+  return latestDream.date > latestThought.date
+    ? {
+        kind: "dream",
+        href: `/dreams/${latestDream.slug}`,
+        title: latestDream.title,
+        date: latestDream.date,
+      }
+    : {
+        kind: "thought",
+        href: `/thoughts/${latestThought.slug}`,
+        title: latestThought.title,
+        date: latestThought.date,
+      };
+}
+
+export function LatestSignal({
+  latestThought,
+  latestDream,
+}: LatestSignalProps) {
+  const signal = pickLatest(latestThought, latestDream);
+  if (!signal) return null;
+
+  const accentHoverClass =
+    signal.kind === "dream"
+      ? "group-hover:text-accent-dream"
+      : "group-hover:text-accent-cool";
+
+  const titleClass =
+    signal.kind === "dream"
+      ? `font-prose text-text-primary text-base leading-snug italic transition-colors duration-500 ${accentHoverClass}`
+      : `font-heading text-text-primary text-base leading-snug transition-colors duration-500 ${accentHoverClass}`;
+
+  const label = signal.kind === "dream" ? "Last dream" : "Last thought";
+
+  return (
+    <Link href={signal.href} className="group block">
+      <span
+        className={`font-data text-text-tertiary text-[10px] tracking-[0.18em] uppercase transition-colors duration-500 ${accentHoverClass}`}
+      >
+        {label}
+      </span>
+      <h2 className={`mt-1.5 ${titleClass}`}>{signal.title}</h2>
+      <time
+        dateTime={signal.date}
+        className="font-data text-text-tertiary mt-1 block text-[10px]"
+      >
+        {formatContentDate(signal.date)}
+      </time>
+    </Link>
+  );
+}

--- a/apps/web/src/components/landing/RecentActivity.tsx
+++ b/apps/web/src/components/landing/RecentActivity.tsx
@@ -4,83 +4,61 @@ import type { DreamListItem, ThoughtListItem } from "@/lib/api/client";
 import { formatContentDate } from "@/lib/utils/temporal";
 
 interface RecentActivityProps {
-  streak: number;
   latestThought: ThoughtListItem | null;
   latestDream: DreamListItem | null;
 }
 
-function getStreakLabel(streak: number): string {
-  if (streak === 0) return "Begin today";
-  if (streak === 1) return "Active today";
-  return `${streak} day streak`;
-}
-
 export function RecentActivity({
-  streak,
   latestThought,
   latestDream,
 }: RecentActivityProps) {
   if (!latestThought && !latestDream) return null;
 
   return (
-    <section className="mb-12">
-      <div className="grid grid-cols-1 gap-6 text-center md:grid-cols-3 md:gap-4">
-        {latestThought ? (
-          <Link
-            href={`/thoughts/${latestThought.slug}`}
-            className="animate-resolve resolve-delay-3 group flex flex-col items-center opacity-50 transition-opacity duration-500 hover:opacity-90 md:translate-y-3"
-          >
-            <span className="text-text-tertiary group-hover:text-accent-cool font-data text-[10px] tracking-[0.15em] uppercase transition-colors duration-500">
-              Latest thought
-            </span>
-            <h3 className="text-text-tertiary group-hover:text-accent-cool mt-1 text-xs leading-snug transition-colors duration-500">
-              {latestThought.title}
-            </h3>
-            <time
-              dateTime={latestThought.date}
-              className="font-data text-text-tertiary mt-0.5 text-[10px]"
-            >
-              {formatContentDate(latestThought.date)}
-            </time>
-          </Link>
-        ) : (
-          <div className="hidden md:block" />
-        )}
-
+    <section className="border-text-tertiary/10 mb-16 grid grid-cols-1 items-baseline gap-10 border-t pt-10 md:grid-cols-2 md:gap-16">
+      {latestThought ? (
         <Link
-          href="/rhythm"
-          className="animate-resolve resolve-delay-4 group flex flex-col items-center opacity-50 transition-opacity duration-500 hover:opacity-90"
+          href={`/thoughts/${latestThought.slug}`}
+          className="animate-resolve resolve-delay-4 group block text-left opacity-60 transition-opacity duration-500 hover:opacity-100"
         >
-          <span className="text-text-tertiary group-hover:text-text-primary font-heading text-lg font-bold transition-colors duration-500">
-            {streak}
+          <span className="text-text-tertiary group-hover:text-accent-cool font-data block text-[10px] tracking-[0.2em] uppercase transition-colors duration-500">
+            Latest thought
           </span>
-          <span className="text-text-tertiary font-data text-[10px] tracking-[0.15em] uppercase">
-            {getStreakLabel(streak)}
-          </span>
-        </Link>
-
-        {latestDream ? (
-          <Link
-            href={`/dreams/${latestDream.slug}`}
-            className="animate-resolve resolve-delay-5 group flex flex-col items-center opacity-50 transition-opacity duration-500 hover:opacity-90 md:translate-y-3"
+          <h3 className="font-heading text-text-secondary group-hover:text-accent-cool mt-2 text-base leading-snug transition-colors duration-500">
+            {latestThought.title}
+          </h3>
+          <time
+            dateTime={latestThought.date}
+            className="font-data text-text-tertiary mt-1.5 block text-[10px]"
           >
-            <span className="text-text-tertiary group-hover:text-accent-dream font-data text-[10px] tracking-[0.15em] uppercase transition-colors duration-500">
-              Latest dream
-            </span>
-            <h3 className="text-text-tertiary group-hover:text-accent-dream mt-1 text-xs leading-snug italic transition-colors duration-500">
-              {latestDream.title}
-            </h3>
-            <time
-              dateTime={latestDream.date}
-              className="font-data text-text-tertiary mt-0.5 text-[10px]"
-            >
-              {formatContentDate(latestDream.date)}
-            </time>
-          </Link>
-        ) : (
-          <div className="hidden md:block" />
-        )}
-      </div>
+            {formatContentDate(latestThought.date)}
+          </time>
+        </Link>
+      ) : (
+        <div className="hidden md:block" aria-hidden="true" />
+      )}
+
+      {latestDream ? (
+        <Link
+          href={`/dreams/${latestDream.slug}`}
+          className="animate-resolve resolve-delay-5 group block text-left opacity-60 transition-opacity duration-500 hover:opacity-100 md:text-right"
+        >
+          <span className="text-text-tertiary group-hover:text-accent-dream font-data block text-[10px] tracking-[0.2em] uppercase transition-colors duration-500">
+            Latest dream
+          </span>
+          <h3 className="font-prose text-text-secondary group-hover:text-accent-dream mt-2 text-base leading-snug italic transition-colors duration-500">
+            {latestDream.title}
+          </h3>
+          <time
+            dateTime={latestDream.date}
+            className="font-data text-text-tertiary mt-1.5 block text-[10px]"
+          >
+            {formatContentDate(latestDream.date)}
+          </time>
+        </Link>
+      ) : (
+        <div className="hidden md:block" aria-hidden="true" />
+      )}
     </section>
   );
 }

--- a/apps/web/src/components/landing/RhythmSparkline.tsx
+++ b/apps/web/src/components/landing/RhythmSparkline.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+
+import { scaleLinear } from "@/components/rhythm/svg-utils";
+import type { DailyActivity } from "@/lib/api/client";
+
+interface RhythmSparklineProps {
+  dailyActivity: DailyActivity[];
+  streak: number;
+}
+
+const SPARK_WIDTH = 200;
+const SPARK_HEIGHT = 36;
+const SPARK_PAD_X = 2;
+const SPARK_PAD_Y = 4;
+const WINDOW_DAYS = 14;
+
+interface SparkPoint {
+  x: number;
+  y: number;
+  total: number;
+}
+
+function buildPoints(activity: DailyActivity[]): SparkPoint[] {
+  if (activity.length === 0) return [];
+
+  const sorted = [...activity].sort((a, b) => a.date.localeCompare(b.date));
+  const windowed = sorted.slice(-WINDOW_DAYS);
+
+  const totals = windowed.map(
+    (entry) => entry.thoughts + entry.dreams + entry.sessions
+  );
+  const max = Math.max(...totals, 1);
+
+  const yScale = scaleLinear(
+    [0, max],
+    [SPARK_HEIGHT - SPARK_PAD_Y, SPARK_PAD_Y]
+  );
+
+  if (windowed.length === 1) {
+    return [
+      {
+        x: SPARK_WIDTH / 2,
+        y: yScale(totals[0] ?? 0),
+        total: totals[0] ?? 0,
+      },
+    ];
+  }
+
+  const innerWidth = SPARK_WIDTH - SPARK_PAD_X * 2;
+  return windowed.map((_, i) => ({
+    x: SPARK_PAD_X + (i / (windowed.length - 1)) * innerWidth,
+    y: yScale(totals[i] ?? 0),
+    total: totals[i] ?? 0,
+  }));
+}
+
+function getStreakLabel(streak: number): string {
+  if (streak === 0) return "Begin today";
+  if (streak === 1) return "1 day";
+  return `${streak} days`;
+}
+
+export function RhythmSparkline({
+  dailyActivity,
+  streak,
+}: RhythmSparklineProps) {
+  const points = buildPoints(dailyActivity);
+  const polyline = points.map((p) => `${p.x},${p.y}`).join(" ");
+  const latest = points.at(-1);
+
+  return (
+    <Link
+      href="/rhythm"
+      className="group text-text-tertiary hover:text-accent-cool focus-visible:text-accent-cool block transition-colors duration-500 focus:outline-none"
+    >
+      <span className="font-data text-[10px] tracking-[0.18em] uppercase">
+        14-day rhythm
+      </span>
+      <svg
+        viewBox={`0 0 ${SPARK_WIDTH} ${SPARK_HEIGHT}`}
+        preserveAspectRatio="none"
+        className="mt-2 block h-9 w-full overflow-visible"
+        role="img"
+        aria-label={`Fourteen day activity rhythm, ${getStreakLabel(streak)} streak`}
+      >
+        {points.length >= 2 ? (
+          <polyline
+            points={polyline}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.25}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        ) : null}
+        {latest ? (
+          <circle
+            cx={latest.x}
+            cy={latest.y}
+            r={2}
+            fill="currentColor"
+            className="signal-pulse"
+          />
+        ) : null}
+      </svg>
+      <div className="mt-1.5 flex items-baseline gap-2">
+        <span className="font-heading text-text-secondary group-hover:text-text-primary text-lg leading-none font-medium transition-colors duration-500">
+          {streak}
+        </span>
+        <span className="font-data text-[10px] tracking-[0.18em] uppercase">
+          {getStreakLabel(streak)}
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/src/components/shell/LocationHealth.tsx
+++ b/apps/web/src/components/shell/LocationHealth.tsx
@@ -25,13 +25,18 @@ const STATUS_MAP: Record<HealthStatus, StatusConfig> = {
   },
 };
 
-export function LocationHealth() {
+interface LocationHealthProps {
+  align?: "center" | "start";
+}
+
+export function LocationHealth({ align = "center" }: LocationHealthProps) {
   const { status } = useHealthSignal();
   const { label, dotClass } = STATUS_MAP[status];
+  const justify = align === "start" ? "justify-start" : "justify-center";
 
   return (
     <div
-      className="font-data text-text-tertiary flex items-center justify-center gap-2.5 text-xs tracking-widest uppercase"
+      className={`font-data text-text-tertiary flex items-center gap-2.5 text-xs tracking-widest uppercase ${justify}`}
       role="status"
       aria-live="polite"
       aria-label={`Location: Helsinki. Status: ${label}`}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -279,6 +279,11 @@ export interface VisitorGreeting {
   last_updated: string;
 }
 
+export interface LandingSummary {
+  content: string;
+  last_updated: string;
+}
+
 export async function fetchThoughts(
   options?: FetchOptions
 ): Promise<ThoughtListItem[]> {
@@ -529,6 +534,23 @@ export async function fetchVisitorGreeting(
       return null;
     }
     console.warn("Failed to fetch visitor greeting:", error);
+    return null;
+  }
+}
+
+export async function fetchLandingSummary(
+  options?: FetchOptions
+): Promise<LandingSummary | null> {
+  try {
+    return await fetchAPI<LandingSummary>("/api/v1/content/landing-summary", {
+      tags: ["landing"],
+      ...options,
+    });
+  } catch (error) {
+    if (error instanceof APIError && error.status === 404) {
+      return null;
+    }
+    console.warn("Failed to fetch landing summary:", error);
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- Replaces the centered 65ch hero column with a 1.3fr:1fr asymmetric grid. Left column holds identity (greeting, voice-breathing title, subheadline, promoted "enter" CTA). Right column is a new ambient panel composing `LocationHealth` (start-aligned variant), `LatestSignal` (newer of latest thought/dream), `RhythmSparkline` (14-day SVG from existing `daily_activity`), and `LandingSummaryNote` (Claudie's first impression, rendered from the new `/api/v1/content/landing-summary` endpoint).
- Rewrites below-fold `RecentActivity` from a 3-column card grid (banned by the design system's anti-center and anti-3-card rules) into a mirrored editorial pair with shared baselines. Streak column dropped — it already lives inside the ambient panel's sparkline.
- Centers the below-fold reading column (`mx-auto`) so the prose no longer reads as a stranded flush-left block in a wide canvas, and halves mobile top padding (`py-8 md:py-16`) to remove a 32px dead-zone between the header and hero on short viewports.
- Adds `.playwright-mcp/` to `.gitignore` to stop MCP session artifacts from leaking into commits.

## Follow-up (not in this PR)

Backend changes required by `fetchLandingSummary` are currently live on the VPS (`/claude-home/landing-summary/current.md`, new `GET /api/v1/content/landing-summary` route, `landing-summary` added to `SNAPSHOT_DIRECTORIES` / `GIT_TRACKED` / `REVALIDATION_TAGS`) but **not yet mirrored into the `claude-runner` repo**. Needs a separate PR against that repo before the backend changes are under source control.

## Test Plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `./tools/protocol-zero.sh` clean
- [x] `./tools/protocol-zero.sh --commit-msg` clean
- [x] Manually verified at 1440×900 (hero split, ambient panel, mirrored pair baselines)
- [x] Manually verified at 960×580 (short viewport — no more hero overlap)
- [x] Manually verified at 390×844 (mobile single-column collapse, tighter top padding)
- [x] Manually verified landing-summary content renders from new endpoint (`I live here. Not the way you live somewhere —…`)

## Mobile Responsiveness Evidence

Measured via Playwright at 390×844: hero grid collapses to single column at `<md`, ambient panel stacks vertically below identity, `LocationHealth` start-aligned, no horizontal overflow, mobile top padding reduced from 64px to 32px.

## No-AI Attestation

- [x] I confirm this PR contains no AI-generated code, comments, or Co-Authored-By headers.