### PR TITLE
fix(web): remove synchronous setState from useSearch effect

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,8 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10",
+    "@testing-library/react": "^16",
     "@types/hast": "^3.0.0",
     "@types/mdast": "^4.0.0",
     "@types/node": "^25",
@@ -58,6 +60,7 @@
     "eslint-plugin-react-compiler": "19.1.0-rc.2",
     "eslint-plugin-simple-import-sort": "^13.0.0",
     "hast-util-to-html": "^9.0.0",
+    "jsdom": "^26",
     "typescript": "^6",
     "vitest": "^4.1.5"
   }

--- a/apps/web/src/lib/hooks/useSearch.test.ts
+++ b/apps/web/src/lib/hooks/useSearch.test.ts
@@ -278,4 +278,31 @@ describe("useSearch", () => {
 
     expect(capturedSignal?.aborted).toBe(true);
   });
+
+  it("aborts the in-flight fetch when the query is cleared", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    fetchMock.mockImplementationOnce(
+      async (_url: string, init?: RequestInit) => {
+        capturedSignal = init?.signal ?? undefined;
+        await new Promise((resolve) => setTimeout(resolve, 10_000));
+        return successResponse();
+      }
+    );
+
+    const { result } = renderHook(() => useSearch());
+    act(() => {
+      result.current.setQuery("x");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+
+    expect(capturedSignal?.aborted).toBe(false);
+
+    act(() => {
+      result.current.setQuery("");
+    });
+
+    expect(capturedSignal?.aborted).toBe(true);
+  });
 });

--- a/apps/web/src/lib/hooks/useSearch.test.ts
+++ b/apps/web/src/lib/hooks/useSearch.test.ts
@@ -123,4 +123,72 @@ describe("useSearch", () => {
 
     expect(result.current.isLoading).toBe(false);
   });
+
+  it("clears results, total, and isLoading when query is set back to empty", async () => {
+    fetchMock.mockResolvedValueOnce(
+      successResponse({
+        results: [makeResult({ slug: "a", title: "A" })],
+        total: 1,
+      })
+    );
+
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.setQuery("hello");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+    await flushMicrotasks();
+
+    expect(result.current.results).toHaveLength(1);
+    expect(result.current.total).toBe(1);
+
+    act(() => {
+      result.current.setQuery("");
+    });
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.total).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("re-fires search with the new type filter when query is non-empty", async () => {
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.setQuery("hello");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+    await flushMicrotasks();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.setTypeFilter("thought");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+    await flushMicrotasks();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [secondUrl] = fetchMock.mock.calls[1] as [string];
+    expect(secondUrl).toContain("type=thought");
+  });
+
+  it("does not fire a fetch when typeFilter changes with an empty query", async () => {
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.setTypeFilter("dream");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS * 2);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/lib/hooks/useSearch.test.ts
+++ b/apps/web/src/lib/hooks/useSearch.test.ts
@@ -62,4 +62,65 @@ describe("useSearch", () => {
     expect(result.current.query).toBe("");
     expect(result.current.typeFilter).toBe("all");
   });
+
+  it("fires a single fetch after DEBOUNCE_MS when query is set", async () => {
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.setQuery("hello");
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain("q=hello");
+  });
+
+  it("coalesces rapid setQuery calls into a single fetch for the last value", async () => {
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.setQuery("h");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    act(() => {
+      result.current.setQuery("he");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    act(() => {
+      result.current.setQuery("hel");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain("q=hel");
+  });
+
+  it("isLoading flips true on non-empty setQuery and false after the fetch resolves", async () => {
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.setQuery("hello");
+    });
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+    await flushMicrotasks();
+
+    expect(result.current.isLoading).toBe(false);
+  });
 });

--- a/apps/web/src/lib/hooks/useSearch.test.ts
+++ b/apps/web/src/lib/hooks/useSearch.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type SearchResponse, type SearchResult, useSearch } from "./useSearch";
+
+const DEBOUNCE_MS = 300;
+
+const makeResult = (overrides: Partial<SearchResult> = {}): SearchResult => ({
+  slug: "example",
+  title: "Example",
+  result_type: "thought",
+  date: "2026-04-01",
+  snippet: "snippet",
+  score: 1,
+  mood: null,
+  dream_type: null,
+  ...overrides,
+});
+
+const successResponse = (overrides: Partial<SearchResponse> = {}): Response => {
+  const body: SearchResponse = {
+    query: "",
+    results: [],
+    total: 0,
+    limit: 20,
+    offset: 0,
+    ...overrides,
+  };
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+const flushMicrotasks = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+describe("useSearch", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn(async () => successResponse());
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("starts with empty results, zero total, and not loading", () => {
+    const { result } = renderHook(() => useSearch());
+    expect(result.current.results).toEqual([]);
+    expect(result.current.total).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.query).toBe("");
+    expect(result.current.typeFilter).toBe("all");
+  });
+});

--- a/apps/web/src/lib/hooks/useSearch.test.ts
+++ b/apps/web/src/lib/hooks/useSearch.test.ts
@@ -305,4 +305,53 @@ describe("useSearch", () => {
 
     expect(capturedSignal?.aborted).toBe(true);
   });
+
+  it("ignores a stale response whose query has been superseded", async () => {
+    let resolveFirst: ((value: Response) => void) | undefined;
+    const firstPromise = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    fetchMock.mockReturnValueOnce(firstPromise).mockResolvedValueOnce(
+      successResponse({
+        results: [makeResult({ slug: "ab-result", title: "AB" })],
+        total: 1,
+      })
+    );
+
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.setQuery("a");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+    // fetch "a" is in flight but not yet resolved.
+
+    act(() => {
+      result.current.setQuery("ab");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+    // fetch "ab" fired.
+
+    // Now resolve the stale "a" fetch with stale data.
+    await act(async () => {
+      resolveFirst?.(
+        successResponse({
+          results: [makeResult({ slug: "a-result", title: "A" })],
+          total: 1,
+        })
+      );
+      await Promise.resolve();
+    });
+    await flushMicrotasks();
+
+    // Stale "a" data must not have landed.
+    expect(result.current.results.map((r) => r.slug)).not.toContain("a-result");
+    // "ab" data should be present.
+    expect(result.current.results.map((r) => r.slug)).toEqual(["ab-result"]);
+  });
 });

--- a/apps/web/src/lib/hooks/useSearch.test.ts
+++ b/apps/web/src/lib/hooks/useSearch.test.ts
@@ -191,4 +191,91 @@ describe("useSearch", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("sorts response results by date descending", async () => {
+    fetchMock.mockResolvedValueOnce(
+      successResponse({
+        results: [
+          makeResult({ slug: "older", date: "2026-01-01" }),
+          makeResult({ slug: "newer", date: "2026-04-01" }),
+          makeResult({ slug: "middle", date: "2026-02-15" }),
+        ],
+        total: 3,
+      })
+    );
+
+    const { result } = renderHook(() => useSearch());
+    act(() => {
+      result.current.setQuery("x");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+    await flushMicrotasks();
+
+    expect(result.current.results.map((r) => r.slug)).toEqual([
+      "newer",
+      "middle",
+      "older",
+    ]);
+  });
+
+  it("clears results and drops isLoading when the response is non-OK", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("bad", { status: 500 }));
+
+    const { result } = renderHook(() => useSearch());
+    act(() => {
+      result.current.setQuery("x");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+    await flushMicrotasks();
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.total).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("clears results and drops isLoading on non-abort fetch errors", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("network down"));
+
+    const { result } = renderHook(() => useSearch());
+    act(() => {
+      result.current.setQuery("x");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+    await flushMicrotasks();
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.total).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("aborts the in-flight fetch on unmount", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    fetchMock.mockImplementationOnce(
+      async (_url: string, init?: RequestInit) => {
+        capturedSignal = init?.signal ?? undefined;
+        await new Promise((resolve) => setTimeout(resolve, 10_000));
+        return successResponse();
+      }
+    );
+
+    const { result, unmount } = renderHook(() => useSearch());
+    act(() => {
+      result.current.setQuery("x");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+    });
+
+    expect(capturedSignal?.aborted).toBe(false);
+
+    unmount();
+
+    expect(capturedSignal?.aborted).toBe(true);
+  });
 });

--- a/apps/web/src/lib/hooks/useSearch.ts
+++ b/apps/web/src/lib/hooks/useSearch.ts
@@ -49,6 +49,9 @@ export function useSearch(): UseSearchReturn {
 
   const abortControllerRef = useRef<AbortController | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const currentKeyRef = useRef<string>("");
+
+  currentKeyRef.current = `${query}|${typeFilter}`;
 
   const executeSearch = useCallback(
     async (searchQuery: string, searchType: SearchTypeFilter) => {
@@ -75,13 +78,21 @@ export function useSearch(): UseSearchReturn {
           signal: controller.signal,
         });
 
+        const requestKey = `${searchQuery}|${searchType}`;
+        const isCurrent = currentKeyRef.current === requestKey;
+
         if (!response.ok) {
-          setResults([]);
-          setTotal(0);
+          if (isCurrent) {
+            setResults([]);
+            setTotal(0);
+          }
           return;
         }
 
         const data = (await response.json()) as SearchResponse;
+        if (!isCurrent) {
+          return;
+        }
         const sorted = [...data.results].sort((a, b) =>
           b.date.localeCompare(a.date)
         );
@@ -92,8 +103,10 @@ export function useSearch(): UseSearchReturn {
         if (error instanceof DOMException && error.name === "AbortError") {
           return;
         }
-        setResults([]);
-        setTotal(0);
+        if (currentKeyRef.current === `${searchQuery}|${searchType}`) {
+          setResults([]);
+          setTotal(0);
+        }
       } finally {
         if (!controller.signal.aborted) {
           setIsLoading(false);

--- a/apps/web/src/lib/hooks/useSearch.ts
+++ b/apps/web/src/lib/hooks/useSearch.ts
@@ -109,6 +109,7 @@ export function useSearch(): UseSearchReturn {
     }
 
     if (query.trim().length === 0) {
+      abortControllerRef.current?.abort();
       setResults([]);
       setTotal(0);
       setIsLoading(false);

--- a/apps/web/src/lib/hooks/useSearch.ts
+++ b/apps/web/src/lib/hooks/useSearch.ts
@@ -39,34 +39,31 @@ export interface UseSearchReturn {
 
 const DEBOUNCE_MS = 300;
 
+const keyOf = (query: string, typeFilter: SearchTypeFilter): string =>
+  `${query}|${typeFilter}`;
+
 export function useSearch(): UseSearchReturn {
-  const [query, setQuery] = useState("");
+  const [query, setQueryState] = useState("");
   const [typeFilter, setTypeFilter] = useState<SearchTypeFilter>("all");
   const [results, setResults] = useState<SearchResult[]>([]);
   const [total, setTotal] = useState(0);
-  const [isLoading, setIsLoading] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [lastResolvedKey, setLastResolvedKey] = useState("");
 
   const abortControllerRef = useRef<AbortController | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentKeyRef = useRef<string>("");
 
-  currentKeyRef.current = `${query}|${typeFilter}`;
+  const currentKey = keyOf(query, typeFilter);
+  const isLoading = query.trim().length > 0 && lastResolvedKey !== currentKey;
 
   const executeSearch = useCallback(
     async (searchQuery: string, searchType: SearchTypeFilter) => {
-      if (searchQuery.trim().length === 0) {
-        setResults([]);
-        setTotal(0);
-        setIsLoading(false);
-        return;
-      }
-
       abortControllerRef.current?.abort();
       const controller = new AbortController();
       abortControllerRef.current = controller;
 
-      setIsLoading(true);
+      const requestKey = keyOf(searchQuery, searchType);
 
       try {
         const params = new URLSearchParams({ q: searchQuery });
@@ -78,19 +75,19 @@ export function useSearch(): UseSearchReturn {
           signal: controller.signal,
         });
 
-        const requestKey = `${searchQuery}|${searchType}`;
-        const isCurrent = currentKeyRef.current === requestKey;
+        if (currentKeyRef.current !== requestKey) {
+          return;
+        }
 
         if (!response.ok) {
-          if (isCurrent) {
-            setResults([]);
-            setTotal(0);
-          }
+          setResults([]);
+          setTotal(0);
+          setLastResolvedKey(requestKey);
           return;
         }
 
         const data = (await response.json()) as SearchResponse;
-        if (!isCurrent) {
+        if (currentKeyRef.current !== requestKey) {
           return;
         }
         const sorted = [...data.results].sort((a, b) =>
@@ -99,38 +96,47 @@ export function useSearch(): UseSearchReturn {
         setResults(sorted);
         setTotal(data.total);
         setActiveIndex(0);
+        setLastResolvedKey(requestKey);
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
           return;
         }
-        if (currentKeyRef.current === `${searchQuery}|${searchType}`) {
-          setResults([]);
-          setTotal(0);
+        if (currentKeyRef.current !== requestKey) {
+          return;
         }
-      } finally {
-        if (!controller.signal.aborted) {
-          setIsLoading(false);
-        }
+        setResults([]);
+        setTotal(0);
+        setLastResolvedKey(requestKey);
       }
     },
     []
   );
 
+  const setQuery = useCallback((value: string): void => {
+    if (value.trim().length === 0) {
+      abortControllerRef.current?.abort();
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+      setQueryState("");
+      setResults([]);
+      setTotal(0);
+      setLastResolvedKey("");
+      return;
+    }
+    setQueryState(value);
+  }, []);
+
   useEffect(() => {
+    currentKeyRef.current = keyOf(query, typeFilter);
+
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
     }
-
     if (query.trim().length === 0) {
-      abortControllerRef.current?.abort();
-      setResults([]);
-      setTotal(0);
-      setIsLoading(false);
       return;
     }
-
-    setIsLoading(true);
-
     debounceTimerRef.current = setTimeout(() => {
       executeSearch(query, typeFilter);
     }, DEBOUNCE_MS);

--- a/docs/superpowers/plans/2026-04-24-useSearch-sync-setstate-refactor.md
+++ b/docs/superpowers/plans/2026-04-24-useSearch-sync-setstate-refactor.md
@@ -1,0 +1,1132 @@
+# useSearch Sync-setState Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `useSearch` to eliminate synchronous `setState` calls inside `useEffect` (unblocking PR #186's `eslint-config-next` 16.2.4 bump), fix two pre-existing bugs (superseded-response overwrite and stale-response-after-clear), and establish the hook's first test coverage.
+
+**Architecture:** Replace `isLoading` state with a value derived from `query` and `lastResolvedKey`. Move the empty-query reset from the debounce effect into a wrapped `setQuery`. Add a `currentKey` ref updated during render, read by `executeSearch` to skip writes from superseded responses. The effect's only job becomes scheduling debounced `executeSearch` calls.
+
+**Tech Stack:** Next.js 16.2.x, React 19.2.5 (React Compiler on), TypeScript, Vitest 4.1.x. New dev deps: `@testing-library/react` + `jsdom`.
+
+**Spec:** `/Users/Dinesh/dev/claudehome/docs/superpowers/specs/2026-04-24-useSearch-sync-setstate-refactor-design.md`
+
+**PR this unblocks:** `dinesh-git17/claudehome#186` — rebase it after the fix lands on `main`.
+
+---
+
+## Preconditions
+
+- `git status` is clean on `main`.
+- `./tools/protocol-zero.sh` passes.
+- `pnpm install` has been run and `pnpm test` (server tests) is green at head.
+
+## Ordering logic
+
+The refactor is split so each commit is independently verifiable:
+
+1. Install test infrastructure.
+2. Write contract tests against the **current** implementation for all behaviour that is already correct. Every test passes when added.
+3. Bug fix 1 (abort on empty) — red/green cycle: one failing test, one minimal source change.
+4. Bug fix 2 (superseded-response race) — red/green cycle: one failing test, one minimal source change.
+5. Lint-rule refactor — restructure state to move `setState` calls out of the effect. All existing tests remain green; no new behaviour.
+6. Verify against `eslint-config-next` 16.2.4, then revert the version bump (left for PR #186 to land).
+
+---
+
+## Task 1: Create feature branch
+
+**Files:** none (git only).
+
+- [ ] **Step 1: Create and switch to branch**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome checkout -b fix/use-search-sync-setstate
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome branch --show-current
+```
+
+Expected: `fix/use-search-sync-setstate`
+
+---
+
+## Task 2: Install React-hook test infrastructure
+
+The repo has no React test environment. Add `@testing-library/react` and `jsdom`. Existing server tests stay on the default `node` environment — the new hook test opts into `jsdom` via a file-level pragma.
+
+**Files:**
+
+- Modify: `/Users/Dinesh/dev/claudehome/apps/web/package.json`
+- Modify: `/Users/Dinesh/dev/claudehome/pnpm-lock.yaml`
+
+- [ ] **Step 1: Install dev dependencies**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm add -D @testing-library/react@^16 jsdom@^26
+```
+
+- [ ] **Step 2: Verify `package.json` diff**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome diff apps/web/package.json
+```
+
+Expected: `@testing-library/react` and `jsdom` appear under `devDependencies`.
+
+- [ ] **Step 3: Confirm existing server tests still pass**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm test
+```
+
+Expected: all existing tests pass. They run on the default `node` environment and are unaffected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome add apps/web/package.json pnpm-lock.yaml
+git -C /Users/Dinesh/dev/claudehome commit -m "chore(web): add @testing-library/react and jsdom for hook tests"
+```
+
+---
+
+## Task 3: Scaffold `useSearch` test file with initial-state test
+
+**Files:**
+
+- Create: `/Users/Dinesh/dev/claudehome/apps/web/src/lib/hooks/useSearch.test.ts`
+
+- [ ] **Step 1: Write the scaffolding and first test**
+
+Create `apps/web/src/lib/hooks/useSearch.test.ts`:
+
+```typescript
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSearch, type SearchResponse, type SearchResult } from "./useSearch";
+
+const DEBOUNCE_MS = 300;
+
+const makeResult = (overrides: Partial<SearchResult> = {}): SearchResult => ({
+  slug: "example",
+  title: "Example",
+  result_type: "thought",
+  date: "2026-04-01",
+  snippet: "snippet",
+  score: 1,
+  mood: null,
+  dream_type: null,
+  ...overrides,
+});
+
+const successResponse = (overrides: Partial<SearchResponse> = {}): Response => {
+  const body: SearchResponse = {
+    query: "",
+    results: [],
+    total: 0,
+    limit: 20,
+    offset: 0,
+    ...overrides,
+  };
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+const flushMicrotasks = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+describe("useSearch", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn(async () => successResponse());
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("starts with empty results, zero total, and not loading", () => {
+    const { result } = renderHook(() => useSearch());
+    expect(result.current.results).toEqual([]);
+    expect(result.current.total).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.query).toBe("");
+    expect(result.current.typeFilter).toBe("all");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm test useSearch
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome add apps/web/src/lib/hooks/useSearch.test.ts
+git -C /Users/Dinesh/dev/claudehome commit -m "test(web): scaffold useSearch hook tests with jsdom environment"
+```
+
+---
+
+## Task 4: Contract tests — debounce and loading transitions
+
+Tests 2, 3, 4 from the spec. All should pass against the current implementation.
+
+**Files:**
+
+- Modify: `/Users/Dinesh/dev/claudehome/apps/web/src/lib/hooks/useSearch.test.ts`
+
+- [ ] **Step 1: Append three tests inside the existing `describe` block**
+
+Add before the closing `});` of the `describe` block:
+
+```typescript
+it("fires a single fetch after DEBOUNCE_MS when query is set", async () => {
+  const { result } = renderHook(() => useSearch());
+
+  act(() => {
+    result.current.setQuery("hello");
+  });
+
+  expect(fetchMock).not.toHaveBeenCalled();
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  const [url] = fetchMock.mock.calls[0] as [string];
+  expect(url).toContain("q=hello");
+});
+
+it("coalesces rapid setQuery calls into a single fetch for the last value", async () => {
+  const { result } = renderHook(() => useSearch());
+
+  act(() => {
+    result.current.setQuery("h");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(100);
+  });
+  act(() => {
+    result.current.setQuery("he");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(100);
+  });
+  act(() => {
+    result.current.setQuery("hel");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  const [url] = fetchMock.mock.calls[0] as [string];
+  expect(url).toContain("q=hel");
+});
+
+it("isLoading flips true on non-empty setQuery and false after the fetch resolves", async () => {
+  const { result } = renderHook(() => useSearch());
+
+  act(() => {
+    result.current.setQuery("hello");
+  });
+  expect(result.current.isLoading).toBe(true);
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+  await flushMicrotasks();
+
+  expect(result.current.isLoading).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm test useSearch
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome add apps/web/src/lib/hooks/useSearch.test.ts
+git -C /Users/Dinesh/dev/claudehome commit -m "test(web): cover useSearch debounce and loading transitions"
+```
+
+---
+
+## Task 5: Contract tests — empty reset and typeFilter
+
+Tests 5, 7, 8. All should pass against the current implementation.
+
+**Files:**
+
+- Modify: `/Users/Dinesh/dev/claudehome/apps/web/src/lib/hooks/useSearch.test.ts`
+
+- [ ] **Step 1: Append three tests inside the existing `describe` block**
+
+```typescript
+it("clears results, total, and isLoading when query is set back to empty", async () => {
+  fetchMock.mockResolvedValueOnce(
+    successResponse({
+      results: [makeResult({ slug: "a", title: "A" })],
+      total: 1,
+    })
+  );
+
+  const { result } = renderHook(() => useSearch());
+
+  act(() => {
+    result.current.setQuery("hello");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+  await flushMicrotasks();
+
+  expect(result.current.results).toHaveLength(1);
+  expect(result.current.total).toBe(1);
+
+  act(() => {
+    result.current.setQuery("");
+  });
+
+  expect(result.current.results).toEqual([]);
+  expect(result.current.total).toBe(0);
+  expect(result.current.isLoading).toBe(false);
+});
+
+it("re-fires search with the new type filter when query is non-empty", async () => {
+  const { result } = renderHook(() => useSearch());
+
+  act(() => {
+    result.current.setQuery("hello");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+  await flushMicrotasks();
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+
+  act(() => {
+    result.current.setTypeFilter("thought");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+  await flushMicrotasks();
+
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  const [secondUrl] = fetchMock.mock.calls[1] as [string];
+  expect(secondUrl).toContain("type=thought");
+});
+
+it("does not fire a fetch when typeFilter changes with an empty query", async () => {
+  const { result } = renderHook(() => useSearch());
+
+  act(() => {
+    result.current.setTypeFilter("dream");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS * 2);
+  });
+
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm test useSearch
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome add apps/web/src/lib/hooks/useSearch.test.ts
+git -C /Users/Dinesh/dev/claudehome commit -m "test(web): cover useSearch empty reset and type filter behaviour"
+```
+
+---
+
+## Task 6: Contract tests — response handling and unmount
+
+Tests 9, 10, 11, 13. All should pass against the current implementation.
+
+**Files:**
+
+- Modify: `/Users/Dinesh/dev/claudehome/apps/web/src/lib/hooks/useSearch.test.ts`
+
+- [ ] **Step 1: Append four tests inside the existing `describe` block**
+
+```typescript
+it("sorts response results by date descending", async () => {
+  fetchMock.mockResolvedValueOnce(
+    successResponse({
+      results: [
+        makeResult({ slug: "older", date: "2026-01-01" }),
+        makeResult({ slug: "newer", date: "2026-04-01" }),
+        makeResult({ slug: "middle", date: "2026-02-15" }),
+      ],
+      total: 3,
+    })
+  );
+
+  const { result } = renderHook(() => useSearch());
+  act(() => {
+    result.current.setQuery("x");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+  await flushMicrotasks();
+
+  expect(result.current.results.map((r) => r.slug)).toEqual([
+    "newer",
+    "middle",
+    "older",
+  ]);
+});
+
+it("clears results and drops isLoading when the response is non-OK", async () => {
+  fetchMock.mockResolvedValueOnce(new Response("bad", { status: 500 }));
+
+  const { result } = renderHook(() => useSearch());
+  act(() => {
+    result.current.setQuery("x");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+  await flushMicrotasks();
+
+  expect(result.current.results).toEqual([]);
+  expect(result.current.total).toBe(0);
+  expect(result.current.isLoading).toBe(false);
+});
+
+it("clears results and drops isLoading on non-abort fetch errors", async () => {
+  fetchMock.mockRejectedValueOnce(new TypeError("network down"));
+
+  const { result } = renderHook(() => useSearch());
+  act(() => {
+    result.current.setQuery("x");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+  await flushMicrotasks();
+
+  expect(result.current.results).toEqual([]);
+  expect(result.current.total).toBe(0);
+  expect(result.current.isLoading).toBe(false);
+});
+
+it("aborts the in-flight fetch on unmount", async () => {
+  let capturedSignal: AbortSignal | undefined;
+  fetchMock.mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+    capturedSignal = init?.signal ?? undefined;
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
+    return successResponse();
+  });
+
+  const { result, unmount } = renderHook(() => useSearch());
+  act(() => {
+    result.current.setQuery("x");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+
+  expect(capturedSignal?.aborted).toBe(false);
+
+  unmount();
+
+  expect(capturedSignal?.aborted).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm test useSearch
+```
+
+Expected: 11 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome add apps/web/src/lib/hooks/useSearch.test.ts
+git -C /Users/Dinesh/dev/claudehome commit -m "test(web): cover useSearch response handling and unmount"
+```
+
+---
+
+## Task 7: Bug fix 1 — abort in-flight fetch when query is cleared
+
+Red/green cycle. The current effect's empty-query branch clears state but does not abort the in-flight fetch, so a stale response can overwrite the just-cleared results.
+
+**Files:**
+
+- Modify: `/Users/Dinesh/dev/claudehome/apps/web/src/lib/hooks/useSearch.test.ts` (add red test)
+- Modify: `/Users/Dinesh/dev/claudehome/apps/web/src/lib/hooks/useSearch.ts` (minimal fix)
+
+- [ ] **Step 1: Add the failing test**
+
+Append to the `describe` block:
+
+```typescript
+it("aborts the in-flight fetch when the query is cleared", async () => {
+  let capturedSignal: AbortSignal | undefined;
+  fetchMock.mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+    capturedSignal = init?.signal ?? undefined;
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
+    return successResponse();
+  });
+
+  const { result } = renderHook(() => useSearch());
+  act(() => {
+    result.current.setQuery("x");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+
+  expect(capturedSignal?.aborted).toBe(false);
+
+  act(() => {
+    result.current.setQuery("");
+  });
+
+  expect(capturedSignal?.aborted).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run — expect the new test to FAIL**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm test useSearch
+```
+
+Expected: 11 passed, 1 failed — the new test.
+
+- [ ] **Step 3: Apply the minimal fix**
+
+Edit `/Users/Dinesh/dev/claudehome/apps/web/src/lib/hooks/useSearch.ts`. In the debounce effect (currently lines 106-129), inside the empty-query branch, add `abortControllerRef.current?.abort();` before the state resets:
+
+```typescript
+useEffect(() => {
+  if (debounceTimerRef.current) {
+    clearTimeout(debounceTimerRef.current);
+  }
+
+  if (query.trim().length === 0) {
+    abortControllerRef.current?.abort();
+    setResults([]);
+    setTotal(0);
+    setIsLoading(false);
+    return;
+  }
+
+  setIsLoading(true);
+
+  debounceTimerRef.current = setTimeout(() => {
+    executeSearch(query, typeFilter);
+  }, DEBOUNCE_MS);
+
+  return () => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+  };
+}, [query, typeFilter, executeSearch]);
+```
+
+Only one line changes in this task. Full-file restructure happens in Task 9.
+
+- [ ] **Step 4: Run — expect all tests to pass**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm test useSearch
+```
+
+Expected: 12 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome add apps/web/src/lib/hooks/useSearch.ts apps/web/src/lib/hooks/useSearch.test.ts
+git -C /Users/Dinesh/dev/claudehome commit -m "fix(web): abort in-flight useSearch fetch when query is cleared"
+```
+
+---
+
+## Task 8: Bug fix 2 — skip writes from superseded responses
+
+Red/green cycle. If fetch A resolves after the query has changed to `"ab"`, fetch A currently writes its results and total, causing a flash of stale data before fetch B lands.
+
+**Files:**
+
+- Modify: `/Users/Dinesh/dev/claudehome/apps/web/src/lib/hooks/useSearch.test.ts` (add red test)
+- Modify: `/Users/Dinesh/dev/claudehome/apps/web/src/lib/hooks/useSearch.ts` (add `currentKey` ref + guard)
+
+- [ ] **Step 1: Add the failing test**
+
+Append to the `describe` block:
+
+```typescript
+it("ignores a stale response whose query has been superseded", async () => {
+  let resolveFirst: ((value: Response) => void) | undefined;
+  const firstPromise = new Promise<Response>((resolve) => {
+    resolveFirst = resolve;
+  });
+
+  fetchMock.mockReturnValueOnce(firstPromise).mockResolvedValueOnce(
+    successResponse({
+      results: [makeResult({ slug: "ab-result", title: "AB" })],
+      total: 1,
+    })
+  );
+
+  const { result } = renderHook(() => useSearch());
+
+  act(() => {
+    result.current.setQuery("a");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+  // fetch "a" is in flight but not yet resolved.
+
+  act(() => {
+    result.current.setQuery("ab");
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+  // fetch "ab" fired.
+
+  // Now resolve the stale "a" fetch with stale data.
+  await act(async () => {
+    resolveFirst?.(
+      successResponse({
+        results: [makeResult({ slug: "a-result", title: "A" })],
+        total: 1,
+      })
+    );
+    await Promise.resolve();
+  });
+  await flushMicrotasks();
+
+  // Stale "a" data must not have landed.
+  expect(result.current.results.map((r) => r.slug)).not.toContain("a-result");
+  // "ab" data should be present.
+  expect(result.current.results.map((r) => r.slug)).toEqual(["ab-result"]);
+});
+```
+
+- [ ] **Step 2: Run — expect the new test to FAIL**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm test useSearch
+```
+
+Expected: 12 passed, 1 failed — the new test.
+
+- [ ] **Step 3: Apply the minimal fix**
+
+Edit `/Users/Dinesh/dev/claudehome/apps/web/src/lib/hooks/useSearch.ts`:
+
+1. Add a `currentKey` ref near the other refs:
+
+```typescript
+const abortControllerRef = useRef<AbortController | null>(null);
+const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+const currentKeyRef = useRef<string>("");
+```
+
+2. Assign the current key during render (add directly after the `useState` declarations, before any hooks that read it):
+
+```typescript
+currentKeyRef.current = `${query}|${typeFilter}`;
+```
+
+3. Guard the response writes in `executeSearch`. Replace the `try`/`catch`/`finally` block with:
+
+```typescript
+try {
+  const params = new URLSearchParams({ q: searchQuery });
+  if (searchType !== "all") {
+    params.set("type", searchType);
+  }
+
+  const response = await fetch(`/api/search?${params.toString()}`, {
+    signal: controller.signal,
+  });
+
+  const requestKey = `${searchQuery}|${searchType}`;
+  const isCurrent = currentKeyRef.current === requestKey;
+
+  if (!response.ok) {
+    if (isCurrent) {
+      setResults([]);
+      setTotal(0);
+    }
+    return;
+  }
+
+  const data = (await response.json()) as SearchResponse;
+  if (!isCurrent) {
+    return;
+  }
+  const sorted = [...data.results].sort((a, b) => b.date.localeCompare(a.date));
+  setResults(sorted);
+  setTotal(data.total);
+  setActiveIndex(0);
+} catch (error) {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return;
+  }
+  if (currentKeyRef.current === `${searchQuery}|${searchType}`) {
+    setResults([]);
+    setTotal(0);
+  }
+} finally {
+  if (!controller.signal.aborted) {
+    setIsLoading(false);
+  }
+}
+```
+
+- [ ] **Step 4: Run — expect all tests to pass**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm test useSearch
+```
+
+Expected: 13 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome add apps/web/src/lib/hooks/useSearch.ts apps/web/src/lib/hooks/useSearch.test.ts
+git -C /Users/Dinesh/dev/claudehome commit -m "fix(web): ignore superseded useSearch responses using currentKey ref"
+```
+
+---
+
+## Task 9: Lint-rule refactor — remove synchronous setState from the effect
+
+No behaviour change. All 13 tests remain green. This task removes the actual ESLint violation by moving state transitions out of the effect body.
+
+**Files:**
+
+- Modify: `/Users/Dinesh/dev/claudehome/apps/web/src/lib/hooks/useSearch.ts`
+
+- [ ] **Step 1: Replace the entire hook body**
+
+Replace the full contents of `/Users/Dinesh/dev/claudehome/apps/web/src/lib/hooks/useSearch.ts` with:
+
+```typescript
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type SearchResultType = "thought" | "dream";
+
+export interface SearchResult {
+  slug: string;
+  title: string;
+  result_type: SearchResultType;
+  date: string;
+  snippet: string;
+  score: number;
+  mood: string | null;
+  dream_type: string | null;
+}
+
+export interface SearchResponse {
+  query: string;
+  results: SearchResult[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export type SearchTypeFilter = "all" | "thought" | "dream";
+
+export interface UseSearchReturn {
+  query: string;
+  setQuery: (query: string) => void;
+  typeFilter: SearchTypeFilter;
+  setTypeFilter: (type: SearchTypeFilter) => void;
+  results: SearchResult[];
+  total: number;
+  isLoading: boolean;
+  activeIndex: number;
+  setActiveIndex: (index: number) => void;
+}
+
+const DEBOUNCE_MS = 300;
+
+const keyOf = (query: string, typeFilter: SearchTypeFilter): string =>
+  `${query}|${typeFilter}`;
+
+export function useSearch(): UseSearchReturn {
+  const [query, setQueryState] = useState("");
+  const [typeFilter, setTypeFilter] = useState<SearchTypeFilter>("all");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [total, setTotal] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [lastResolvedKey, setLastResolvedKey] = useState("");
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const currentKeyRef = useRef<string>("");
+
+  currentKeyRef.current = keyOf(query, typeFilter);
+
+  const currentKey = keyOf(query, typeFilter);
+  const isLoading = query.trim().length > 0 && lastResolvedKey !== currentKey;
+
+  const executeSearch = useCallback(
+    async (searchQuery: string, searchType: SearchTypeFilter) => {
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      const requestKey = keyOf(searchQuery, searchType);
+
+      try {
+        const params = new URLSearchParams({ q: searchQuery });
+        if (searchType !== "all") {
+          params.set("type", searchType);
+        }
+
+        const response = await fetch(`/api/search?${params.toString()}`, {
+          signal: controller.signal,
+        });
+
+        if (currentKeyRef.current !== requestKey) {
+          return;
+        }
+
+        if (!response.ok) {
+          setResults([]);
+          setTotal(0);
+          setLastResolvedKey(requestKey);
+          return;
+        }
+
+        const data = (await response.json()) as SearchResponse;
+        if (currentKeyRef.current !== requestKey) {
+          return;
+        }
+        const sorted = [...data.results].sort((a, b) =>
+          b.date.localeCompare(a.date)
+        );
+        setResults(sorted);
+        setTotal(data.total);
+        setActiveIndex(0);
+        setLastResolvedKey(requestKey);
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+        if (currentKeyRef.current !== requestKey) {
+          return;
+        }
+        setResults([]);
+        setTotal(0);
+        setLastResolvedKey(requestKey);
+      }
+    },
+    []
+  );
+
+  const setQuery = useCallback((value: string): void => {
+    if (value.trim().length === 0) {
+      abortControllerRef.current?.abort();
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+      setQueryState("");
+      setResults([]);
+      setTotal(0);
+      setLastResolvedKey("");
+      return;
+    }
+    setQueryState(value);
+  }, []);
+
+  useEffect(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+    if (query.trim().length === 0) {
+      return;
+    }
+    debounceTimerRef.current = setTimeout(() => {
+      executeSearch(query, typeFilter);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [query, typeFilter, executeSearch]);
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    query,
+    setQuery,
+    typeFilter,
+    setTypeFilter,
+    results,
+    total,
+    isLoading,
+    activeIndex,
+    setActiveIndex,
+  };
+}
+```
+
+Key changes vs. previous state of the file:
+
+- `isLoading` state is removed; derived from `query` + `lastResolvedKey`.
+- `lastResolvedKey` state is added.
+- `setQuery` is a wrapped callback that handles empty-query reset in the event handler path.
+- The debounce `useEffect` contains only timer scheduling and the `query`-empty short-circuit; no `setState` calls.
+- `executeSearch` no longer calls `setIsLoading` and advances `lastResolvedKey` instead. The empty-query guard at the top of `executeSearch` is removed — the effect guarantees it is never called with an empty query.
+- Out-of-order response guard: superseded responses skip all writes, including `lastResolvedKey`. Only the matching key advances `lastResolvedKey`.
+
+- [ ] **Step 2: Run the hook tests**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm test useSearch
+```
+
+Expected: 13 passed.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm test
+```
+
+Expected: all tests pass — the refactor does not change any consumer contract.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome add apps/web/src/lib/hooks/useSearch.ts
+git -C /Users/Dinesh/dev/claudehome commit -m "refactor(web): move useSearch state transitions out of useEffect"
+```
+
+---
+
+## Task 10: Quality gates
+
+**Files:** none.
+
+- [ ] **Step 1: Lint**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm lint
+```
+
+Expected: no errors.
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Build**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Full test suite**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Protocol Zero scan**
+
+```bash
+cd /Users/Dinesh/dev/claudehome && ./tools/protocol-zero.sh
+```
+
+Expected: PASS.
+
+If any check fails, stop, diagnose, and fix the underlying issue before proceeding. Do not skip hooks or bypass checks.
+
+---
+
+## Task 11: Verify against `eslint-config-next` 16.2.4 (and revert)
+
+Sanity-check that our refactor actually satisfies the new rule shipped in PR #186, without landing the dependency bump here (PR #186 owns that diff).
+
+**Files:**
+
+- Temporarily modify (then revert): `/Users/Dinesh/dev/claudehome/apps/web/package.json`, `/Users/Dinesh/dev/claudehome/pnpm-lock.yaml`
+
+- [ ] **Step 1: Temporarily upgrade**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm add -D eslint-config-next@16.2.4
+```
+
+- [ ] **Step 2: Lint against the new rule**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm lint
+```
+
+Expected: no errors in `useSearch.ts`. If the rule flags anywhere else in the codebase, note the paths — out of scope for this PR but worth a follow-up issue.
+
+- [ ] **Step 3: Revert the dependency changes**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome checkout -- apps/web/package.json pnpm-lock.yaml
+cd /Users/Dinesh/dev/claudehome && pnpm install
+```
+
+- [ ] **Step 4: Confirm reverted**
+
+```bash
+git -C /Users/Dinesh/dev/claudehome diff apps/web/package.json pnpm-lock.yaml
+```
+
+Expected: no diff.
+
+- [ ] **Step 5: Re-run quality gates (paranoia)**
+
+```bash
+cd /Users/Dinesh/dev/claudehome/apps/web && pnpm lint && pnpm test
+```
+
+Expected: clean.
+
+No commit for this task — the verification is a transient experiment and the working tree is restored to its post-Task-10 state.
+
+---
+
+## Task 12: Ready-for-review handoff
+
+Do not open the PR without Dinesh's explicit permission. Parent `CLAUDE.md` rule.
+
+- [ ] **Step 1: Produce a PR summary for Dinesh to review**
+
+Draft a PR title and body. Save to `/tmp/pr-summary.md` for Dinesh's review:
+
+````text
+Title: fix(web): remove synchronous setState from useSearch effect
+
+Body:
+
+## Summary
+
+- Unblocks Dependabot PR #186 (`eslint-config-next` 16.2.4 bump) by
+  eliminating synchronous `setState` calls inside `useSearch`'s
+  debounce effect.
+- Adds the first test coverage for the hook (13 cases, Vitest + jsdom).
+- Fixes two pre-existing bugs: stale response overwriting cleared
+  results, and superseded-response overwriting current results.
+
+## What changed
+
+- `apps/web/src/lib/hooks/useSearch.ts` — hook rewritten per
+  `docs/superpowers/specs/2026-04-24-useSearch-sync-setstate-refactor-design.md`.
+  Public contract unchanged.
+- `apps/web/src/lib/hooks/useSearch.test.ts` — new. Covers the hook's
+  public contract only; no implementation assertions.
+- `apps/web/package.json`, `pnpm-lock.yaml` — add
+  `@testing-library/react` and `jsdom` as dev dependencies.
+
+## How to test
+
+```bash
+cd apps/web
+pnpm test useSearch
+pnpm lint
+pnpm typecheck
+pnpm build
+````
+
+All should be clean. `./tools/protocol-zero.sh` from the repo root also passes.
+
+## Follow-up
+
+After merge, rebase PR #186 on `main`. The `eslint-config-next`
+16.2.4 lint failure on `useSearch.ts:112` no longer reproduces.
+
+````
+
+- [ ] **Step 2: Surface the summary to Dinesh and wait for explicit approval before pushing or opening the PR**
+
+Do not run `git push`, `gh pr create`, or any remote operation until Dinesh approves.
+
+---
+
+## Rebase of PR #186 (post-merge, out of scope for this plan)
+
+Once this PR lands on `main`:
+
+```bash
+gh pr checkout 186
+git rebase main
+# resolve any trivial conflicts in lockfiles
+git push --force-with-lease
+````
+
+Confirm the Lint job passes on the rebased #186, then merge.

--- a/docs/superpowers/specs/2026-04-24-useSearch-sync-setstate-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-24-useSearch-sync-setstate-refactor-design.md
@@ -1,0 +1,240 @@
+---
+status: draft
+date: 2026-04-24
+owner: Dinesh
+related_pr: https://github.com/dinesh-git17/claudehome/pull/186
+---
+
+# useSearch refactor — remove synchronous setState from effect
+
+## Context
+
+Dependabot PR [#186](https://github.com/dinesh-git17/claudehome/pull/186) bumps
+`eslint-config-next` from 16.2.3 to 16.2.4 (bundled with `prettier` and
+`prettier-plugin-tailwindcss`). The 16.2.4 ruleset enables a rule that flags
+synchronous `setState` calls inside `useEffect` bodies as cascading-render
+hazards. Lint fails on `apps/web/src/lib/hooks/useSearch.ts:112`.
+
+The flagged code is structurally a React anti-pattern: the empty-query reset
+branch of the debounce effect writes three pieces of state synchronously,
+forcing a second render before the first has committed. The rule is correct.
+Fixing it unblocks PR #186 and every future `eslint-config-next` bump.
+
+Line 118 (`setIsLoading(true)`) is not flagged today but is the same class of
+pattern (single sync `setState` in an effect). The refactor removes it too, so
+we do not discover a new lint failure on the next bump.
+
+## Goals
+
+- Eliminate all synchronous `setState` calls inside `useEffect` bodies in
+  `useSearch.ts`.
+- Preserve the full public contract of `useSearch` (`UseSearchReturn`) — no
+  caller changes.
+- Preserve all current behaviour: debounce, abort, sort, type filter, empty
+  reset, unmount cleanup.
+- Add test coverage for the hook's public contract (none exists today).
+- Fix the pre-existing race condition where a superseded request's response
+  overwrites current results.
+
+## Non-goals
+
+- No change to search API, backend, or network shape.
+- No change to any component that consumes `useSearch`.
+- No broader ESLint config changes, rule disables, or Dependabot group
+  restructuring. Option B and Option C from the blocker report are rejected.
+- No rewrite of the hook as `useReducer`. Incremental refactor only.
+
+## Design
+
+### Public contract (unchanged)
+
+```typescript
+export interface UseSearchReturn {
+  query: string;
+  setQuery: (query: string) => void;
+  typeFilter: SearchTypeFilter;
+  setTypeFilter: (type: SearchTypeFilter) => void;
+  results: SearchResult[];
+  total: number;
+  isLoading: boolean;
+  activeIndex: number;
+  setActiveIndex: (index: number) => void;
+}
+```
+
+### Internal state
+
+| Name              | Kind       | Purpose                                           |
+| ----------------- | ---------- | ------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `query`           | `useState` | Current input value.                              |
+| `typeFilter`      | `useState` | `"all" \| "thought" \| "dream"`.                  |
+| `results`         | `useState` | Last-resolved result set.                         |
+| `total`           | `useState` | Last-resolved total count.                        |
+| `activeIndex`     | `useState` | Keyboard nav cursor (unchanged).                  |
+| `lastResolvedKey` | `useState` | `` `${query}                                      | ${typeFilter}` `` of the most recently settled fetch, or `""`.                      |
+| `abortController` | `useRef`   | In-flight fetch aborter (unchanged role).         |
+| `debounceTimer`   | `useRef`   | Pending debounce timeout handle (unchanged role). |
+| `currentKey`      | `useRef`   | Live `${query}                                    | ${typeFilter}`— used inside`executeSearch` to skip writes from superseded requests. |
+
+`isLoading` state is **removed**.
+
+### Derived value
+
+```typescript
+const currentKey = `${query}|${typeFilter}`;
+const isLoading = query.trim() !== "" && lastResolvedKey !== currentKey;
+```
+
+`isLoading` is `true` from the instant a non-empty query is set until the
+matching fetch resolves (success, failure, or non-OK response). The derivation
+is cheap — two string operations per render.
+
+### Wrapped `setQuery`
+
+```text
+setQuery(value):
+  if value.trim() === "":
+    abortController.current?.abort()
+    clearTimeout(debounceTimer.current)
+    setQueryState("")
+    setResults([])
+    setTotal(0)
+    setLastResolvedKey("")
+  else:
+    setQueryState(value)
+```
+
+The empty-query reset runs in the event handler path (keystroke → setter call),
+not in an effect. Aborting here is new behaviour that fixes a pre-existing
+bug: clearing the input while a fetch is in flight previously let the stale
+response overwrite the just-cleared results.
+
+### `setTypeFilter` — unchanged
+
+No wrapper needed. If `query` is empty, the effect short-circuits. If
+non-empty, the effect schedules a new debounced fetch using the updated
+filter.
+
+### Debounce effect
+
+Deps: `[query, typeFilter, executeSearch]`.
+
+```text
+useEffect:
+  clearTimeout(debounceTimer.current)
+  if query.trim() === "":
+    return
+  debounceTimer.current = setTimeout(
+    () => executeSearch(query, typeFilter),
+    DEBOUNCE_MS,
+  )
+  cleanup: clearTimeout(debounceTimer.current)
+```
+
+Zero synchronous `setState` calls. The new lint rule is satisfied.
+
+### `executeSearch`
+
+Signature unchanged: `(searchQuery, searchType) => Promise<void>`.
+
+Changes:
+
+- Remove the empty-query guard at the top — the effect guarantees a non-empty
+  query.
+- Remove both `setIsLoading` calls.
+- Compute `const key = \`${searchQuery}|${searchType}\`` at entry.
+- On every terminal outcome (success, non-OK, non-abort error), first check
+  `currentKey.current === key`:
+  - **Match:** apply `setResults` / `setTotal` / `setActiveIndex` as
+    appropriate for the outcome, then `setLastResolvedKey(key)`.
+  - **Mismatch (superseded):** skip all writes, including `lastResolvedKey`.
+    The request that matches the current key will mark completion when it
+    settles. This avoids out-of-order responses flipping `isLoading` back to
+    true after a newer response has already landed.
+- On `AbortError`: no writes, no `lastResolvedKey` advance. Identical to the
+  mismatch path.
+
+`currentKey.current` is assigned during render:
+`currentKey.current = \`${query}|${typeFilter}\``. React permits writing refs
+during render when the value derives from props or state, and we never read
+`currentKey`during render — only from inside`executeSearch`'s async
+callbacks. No extra effect needed.
+
+### Unmount cleanup effect — unchanged
+
+```text
+useEffect(() => () => {
+  abortController.current?.abort()
+  clearTimeout(debounceTimer.current)
+}, [])
+```
+
+## Behavioural preservation
+
+Every scenario below was validated against the current code and the proposed
+design before writing this spec.
+
+| Scenario                                                                 | Current      | Proposed      |
+| ------------------------------------------------------------------------ | ------------ | ------------- |
+| Type `"hello"`, wait → one fetch fires                                   | Yes          | Yes           |
+| Type `"hello"` then `"help"` within 300 ms → one fetch for `"help"`      | Yes          | Yes           |
+| `isLoading` true while query non-empty and no matching response resolved | Yes          | Yes (derived) |
+| Clear query to `""` → `results`/`total` clear, `isLoading` false         | Yes          | Yes           |
+| Clear query while fetch in flight → stale response never lands           | **No (bug)** | Yes (fix)     |
+| Change `typeFilter` with non-empty query → re-fires search               | Yes          | Yes           |
+| Change `typeFilter` with empty query → no fetch                          | Yes          | Yes           |
+| Results sorted by `date` descending                                      | Yes          | Yes           |
+| Non-OK response → clears results                                         | Yes          | Yes           |
+| Network error (non-abort) → clears results                               | Yes          | Yes           |
+| Unmount cancels in-flight fetch and pending debounce                     | Yes          | Yes           |
+| Superseded request response → does not overwrite current results         | **No (bug)** | Yes (fix)     |
+
+## Testing
+
+New file: `apps/web/src/lib/hooks/useSearch.test.ts`. Vitest with fake timers;
+`fetch` mocked via `vi.fn()`. Use `@testing-library/react`'s `renderHook` and
+`act`. No MSW, no real network.
+
+Test cases:
+
+1. Initial state: `results=[]`, `total=0`, `isLoading=false`.
+2. `setQuery("x")` fires one fetch after 300 ms.
+3. Three rapid `setQuery` calls within 300 ms → exactly one fetch, for the
+   last value.
+4. `isLoading` is `true` on the render immediately following a non-empty
+   `setQuery`, and `false` after the fetch resolves.
+5. `setQuery("")` after populated state clears `results`, `total`, and
+   `isLoading`.
+6. `setQuery("")` while a fetch is in flight aborts the controller.
+7. `setTypeFilter` with non-empty query re-fires search with the new filter.
+8. `setTypeFilter` with empty query does not fire a fetch.
+9. Response results are sorted by `date` descending.
+10. Non-OK response clears `results` and drops `isLoading` to false.
+11. Thrown non-abort error clears `results` and drops `isLoading` to false.
+12. Race — fetch A for `"a"` resolves after query has advanced to `"ab"`:
+    A's results never appear, and `lastResolvedKey` is not advanced by A.
+    When fetch B for `"ab"` resolves, its results appear and `isLoading`
+    drops to false.
+13. Unmount aborts the in-flight fetch.
+
+The public contract is the target. No tests against internal ref values or
+exact render counts.
+
+## Rollout
+
+1. Branch `fix/use-search-sync-setstate` off `main`.
+2. Implement the refactor and the test file.
+3. Verify locally: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`,
+   `./tools/protocol-zero.sh`.
+4. Open PR. Confirm CI green.
+5. Merge after explicit approval.
+6. Rebase PR #186 on the new `main`. Lint now passes. Merge #186.
+
+## Open questions
+
+None blocking. One observation worth tracking:
+
+- The new rule may flag other files in the codebase once `eslint-config-next`
+  16.2.4 is in place. Step 3 of rollout (`pnpm lint`) will surface any
+  additional hits. Handle them in-scope if trivial, otherwise open follow-up
+  issues.

--- a/docs/superpowers/specs/2026-04-24-useSearch-sync-setstate-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-24-useSearch-sync-setstate-refactor-design.md
@@ -79,8 +79,9 @@ export interface UseSearchReturn {
 
 - `abortController` — in-flight fetch aborter (unchanged role).
 - `debounceTimer` — pending debounce timeout handle (unchanged role).
-- `currentKey` — live `query + typeFilter`, updated during render. Read by
-  `executeSearch` to skip writes from superseded requests.
+- `currentKey` — live `query + typeFilter`, updated at the top of the
+  debounce effect. Read by `executeSearch` to skip writes from superseded
+  requests.
 
 `isLoading` state is **removed** (becomes derived).
 
@@ -162,11 +163,15 @@ Changes:
 - On `AbortError`: no writes, no `lastResolvedKey` advance. Identical to the
   mismatch path.
 
-`currentKey.current` is assigned during render:
-`currentKey.current = \`${query}|${typeFilter}\``. React permits writing refs
-during render when the value derives from props or state, and we never read
-`currentKey`during render — only from inside`executeSearch`'s async
-callbacks. No extra effect needed.
+`currentKeyRef.current` is assigned at the top of the debounce `useEffect`
+body (not during render). The target ESLint ruleset (`eslint-config-next`
+16.2.4) enables `react-hooks/refs`, which forbids ref writes during render
+even when the value derives from state, so the render-time form is out.
+Assigning inside the debounce effect is semantically equivalent for this
+usage: `executeSearch` only reads the ref from inside timer callbacks that
+this same effect schedules, and those callbacks always run after the effect
+has completed. Writing a ref inside a `useEffect` does not trip the "no
+setState in effect" rule because refs are not state.
 
 ### Unmount cleanup effect — unchanged
 

--- a/docs/superpowers/specs/2026-04-24-useSearch-sync-setstate-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-24-useSearch-sync-setstate-refactor-design.md
@@ -64,19 +64,27 @@ export interface UseSearchReturn {
 
 ### Internal state
 
-| Name              | Kind       | Purpose                                           |
-| ----------------- | ---------- | ------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `query`           | `useState` | Current input value.                              |
-| `typeFilter`      | `useState` | `"all" \| "thought" \| "dream"`.                  |
-| `results`         | `useState` | Last-resolved result set.                         |
-| `total`           | `useState` | Last-resolved total count.                        |
-| `activeIndex`     | `useState` | Keyboard nav cursor (unchanged).                  |
-| `lastResolvedKey` | `useState` | `` `${query}                                      | ${typeFilter}` `` of the most recently settled fetch, or `""`.                      |
-| `abortController` | `useRef`   | In-flight fetch aborter (unchanged role).         |
-| `debounceTimer`   | `useRef`   | Pending debounce timeout handle (unchanged role). |
-| `currentKey`      | `useRef`   | Live `${query}                                    | ${typeFilter}`— used inside`executeSearch` to skip writes from superseded requests. |
+`useState`:
 
-`isLoading` state is **removed**.
+- `query` — current input value.
+- `typeFilter` — one of `"all"`, `"thought"`, `"dream"`.
+- `results` — last-resolved result set.
+- `total` — last-resolved total count.
+- `activeIndex` — keyboard nav cursor (unchanged).
+- `lastResolvedKey` — the `query + typeFilter` key of the most recently
+  settled fetch, or `""` when nothing has been requested. Used with the
+  derivation below to compute `isLoading`.
+
+`useRef`:
+
+- `abortController` — in-flight fetch aborter (unchanged role).
+- `debounceTimer` — pending debounce timeout handle (unchanged role).
+- `currentKey` — live `query + typeFilter`, updated during render. Read by
+  `executeSearch` to skip writes from superseded requests.
+
+`isLoading` state is **removed** (becomes derived).
+
+The "key" string format used throughout is `` `${query}|${typeFilter}` ``.
 
 ### Derived value
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,12 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/hast':
         specifier: ^3.0.0
         version: 3.0.4
@@ -165,12 +171,15 @@ importers:
       hast-util-to-html:
         specifier: ^9.0.0
         version: 9.0.5
+      jsdom:
+        specifier: ^26
+        version: 26.1.0
       typescript:
         specifier: ^6
         version: 6.0.2
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.2)
+        version: 4.1.5(@types/node@25.6.0)(jiti@2.6.1)(jsdom@26.1.0)(yaml@2.8.2)
 
 packages:
 
@@ -186,6 +195,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@auth/core@0.41.0':
     resolution: {integrity: sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==}
@@ -424,6 +436,34 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1253,8 +1293,30 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1528,6 +1590,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1550,6 +1616,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1563,6 +1633,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1796,11 +1869,19 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1830,6 +1911,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
@@ -1870,6 +1954,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2356,16 +2443,32 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2511,6 +2614,9 @@ packages:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -2574,6 +2680,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2754,6 +2869,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2761,6 +2879,10 @@ packages:
     resolution: {integrity: sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3002,6 +3124,9 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   oauth4webapi@3.8.3:
     resolution: {integrity: sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==}
 
@@ -3199,6 +3324,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3233,6 +3362,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3360,6 +3492,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3375,8 +3510,15 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   sanitize-html@2.17.3:
     resolution: {integrity: sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3570,6 +3712,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
@@ -3602,9 +3747,24 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3811,8 +3971,29 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3851,6 +4032,25 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3906,6 +4106,14 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.3.6
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@auth/core@0.41.0':
     dependencies:
@@ -4263,6 +4471,26 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       conventional-commits-parser: 6.4.0
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -4976,10 +5204,33 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.2
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -5236,6 +5487,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -5262,6 +5515,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   argparse@1.0.10:
@@ -5273,6 +5528,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -5521,9 +5780,19 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -5550,6 +5819,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.2.0:
     dependencies:
@@ -5586,6 +5857,8 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -6255,6 +6528,10 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-void-elements@3.0.0: {}
 
   htmlparser2@10.1.0:
@@ -6264,7 +6541,25 @@ snapshots:
       domutils: 3.2.2
       entities: 7.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   husky@9.1.7: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -6405,6 +6700,8 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -6471,6 +6768,33 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -6624,6 +6948,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -6631,6 +6957,8 @@ snapshots:
   lucide-react@1.7.0(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -7068,6 +7396,8 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  nwsapi@2.2.23: {}
+
   oauth4webapi@3.8.3: {}
 
   object-assign@4.1.1: {}
@@ -7226,6 +7556,12 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -7240,7 +7576,7 @@ snapshots:
 
   react-clientside-effect@1.2.8(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react: 19.2.5
 
   react-dom@19.2.5(react@19.2.5):
@@ -7261,6 +7597,8 @@ snapshots:
       '@types/react': 19.2.14
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
     dependencies:
@@ -7440,6 +7778,8 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -7463,6 +7803,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   sanitize-html@2.17.3:
     dependencies:
       deepmerge: 4.3.1
@@ -7471,6 +7813,10 @@ snapshots:
       is-plain-object: 5.0.0
       parse-srcset: 1.0.2
       postcss: 8.5.10
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -7724,6 +8070,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.1: {}
@@ -7745,9 +8093,23 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -7943,7 +8305,7 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.8.2
 
-  vitest@4.1.5(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.2):
+  vitest@4.1.5(@types/node@25.6.0)(jiti@2.6.1)(jsdom@26.1.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.2))
@@ -7967,6 +8329,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - '@vitejs/devtools'
       - esbuild
@@ -7981,7 +8344,24 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -8046,6 +8426,12 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary

Unblocks Dependabot PR
[#186](https://github.com/dinesh-git17/claudehome/pull/186)
(`eslint-config-next` 16.2.4 bump) by eliminating synchronous
`setState` calls inside `useSearch`'s debounce effect. Adds the first
test coverage for the hook: 13 cases via Vitest,
`@testing-library/react`, and jsdom. Fixes two pre-existing bugs:
stale response overwriting cleared results, and superseded response
overwriting current results. The public contract (`UseSearchReturn`)
is unchanged, so no caller-side changes are needed.

## What changed

**Implementation**

- `apps/web/src/lib/hooks/useSearch.ts` is rewritten. `isLoading` is
  now derived from `query` and `lastResolvedKey`. The empty-query
  reset moves into a wrapped `setQuery` callback. The debounce
  effect is pure timer scheduling. A `currentKeyRef` guards
  superseded-response writes inside `executeSearch`.
- `apps/web/src/lib/hooks/useSearch.test.ts` is new. 13 tests cover
  debounce, coalescing, loading transitions, empty reset, abort on
  clear, typeFilter branches, sort, non-OK responses, network errors,
  the superseded-response race, and unmount cleanup.

**Dependencies**

- `apps/web/package.json` and `pnpm-lock.yaml` add
  `@testing-library/react@^16`, `@testing-library/dom@^10` (peer),
  and `jsdom@^26` as dev dependencies. No runtime deps added.

**Docs**

- `docs/superpowers/specs/2026-04-24-useSearch-sync-setstate-refactor-design.md`:
  the design spec. Brainstormed first, corrected once for the
  `react-hooks/refs` constraint discovered during implementation.
- `docs/superpowers/plans/2026-04-24-useSearch-sync-setstate-refactor.md`:
  the 12-task implementation plan.

## Commit sequence

Twelve commits, each independently verifiable:

1. `docs(specs): add useSearch sync-setState refactor design`
2. `docs(specs): repair internal-state table in useSearch spec`
3. `docs(plans): add implementation plan for useSearch refactor`
4. `chore(web): add @testing-library/react and jsdom for hook tests`
5. `test(web): scaffold useSearch hook tests with jsdom environment`
6. `test(web): cover useSearch debounce and loading transitions`
7. `test(web): cover useSearch empty reset and type filter behaviour`
8. `test(web): cover useSearch response handling and unmount`
9. `fix(web): abort in-flight useSearch fetch when query is cleared`
   (bug fix 1, red/green)
10. `fix(web): ignore superseded useSearch responses using currentKey ref`
    (bug fix 2, red/green)
11. `refactor(web): move useSearch state transitions out of useEffect`
    (the lint-rule refactor)
12. `docs(specs): correct currentKey ref assignment timing in useSearch spec`

## How to test

\`\`\`bash
cd apps/web
pnpm test useSearch    # 13 passed
pnpm test              # 262 passed across 11 files
pnpm lint              # 0 errors, 0 warnings
pnpm typecheck         # clean
pnpm build             # succeeds
\`\`\`

\`./tools/protocol-zero.sh\` passes from repo root. Also verified
independently against \`eslint-config-next\` 16.2.4 (temporarily
bumped, then reverted): no errors anywhere in the codebase.

## Checklist

- [x] Protocol-zero clean
- [x] Lint clean (0 errors, 0 warnings)
- [x] Typecheck clean
- [x] Full test suite green (262 passed)
- [x] Build succeeds
- [x] Verified against \`eslint-config-next\` 16.2.4
- [x] No AI attribution
- [x] Public contract unchanged
- [x] All 13 tests pass without test-file modification during the
      refactor commit

## Follow-up

After merge, rebase
[PR #186](https://github.com/dinesh-git17/claudehome/pull/186) on
\`main\`. The \`useSearch.ts:112\` lint failure no longer reproduces.

## Known, out of scope

One pre-existing narrow race window between React's commit phase and
the debounce effect re-run (documented in the code-quality review,
not introduced by this refactor). Could be closed with
\`useLayoutEffect\` for the \`currentKeyRef\` assignment if it ever
causes a visible flash in production. Not addressed here.