### PR TITLE
fix(api): drop client_ip from moderation log payload

### DIFF
--- a/apps/web/src/app/api/visitors/route.ts
+++ b/apps/web/src/app/api/visitors/route.ts
@@ -123,7 +123,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     allowed: moderationResult.allowed,
     reason: moderationResult.reason,
     sentiment: moderationResult.sentiment,
-    client_ip: clientIp,
   }).catch(() => {});
 
   if (!moderationResult.allowed) {

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+beforeAll(() => {
+  process.env.CLAUDE_API_URL = "http://localhost:8000";
+  process.env.CLAUDE_API_KEY = "test-key";
+});
+
+import { postModerationLog } from "./client";
+
+const fetchMock = vi.fn();
+
+vi.stubGlobal("fetch", fetchMock);
+
+afterEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("postModerationLog", () => {
+  it("forwards a payload that does not include client_ip", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    await postModerationLog({
+      name: "alice",
+      message_preview: "hello",
+      allowed: true,
+      reason: "approved",
+      sentiment: "neutral",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body =
+      init && typeof init === "object" && "body" in init
+        ? JSON.parse(String(init.body))
+        : {};
+    expect(body).not.toHaveProperty("client_ip");
+    expect(body).toMatchObject({
+      name: "alice",
+      message_preview: "hello",
+      allowed: true,
+      reason: "approved",
+      sentiment: "neutral",
+    });
+  });
+});

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -585,7 +585,6 @@ export interface ModerationLogRequest {
   allowed: boolean;
   reason: string;
   sentiment: string;
-  client_ip: string;
 }
 
 export async function postModerationLog(


### PR DESCRIPTION
## Summary

- Drop `client_ip` from the `ModerationLogRequest` interface and from the `postModerationLog` call in the visitors route.
- The `/privacy` page commits to not persisting visitor IPs in moderation logs; this brings the frontend payload in line.
- Companion to claude-runner PR #45, which removes `client_ip` from the FastAPI moderation model and stops persisting it to disk.

## What changed

- `apps/web/src/lib/api/client.ts`: removed `client_ip: string` from `ModerationLogRequest`.
- `apps/web/src/app/api/visitors/route.ts`: removed `client_ip: clientIp` from the `postModerationLog` call. `getClientIp(request)` is still used for the Vercel rate limit.
- `apps/web/src/lib/api/client.test.ts`: new regression test asserting the outgoing payload does not include `client_ip`.

## How to test

- `pnpm build` — passes
- `pnpm typecheck` — passes
- `pnpm lint` — 0 errors (1 pre-existing warning unrelated to this change)
- `pnpm test src/lib/api/client.test.ts` — passes
- `./tools/protocol-zero.sh` — PASS

## Checklist

- [x] Frontend stops sending `client_ip`
- [x] Regression test added
- [x] All gates green
- [x] Companion runner PR open (#45)